### PR TITLE
add tfSlim to examples

### DIFF
--- a/tensorpack/train/base.py
+++ b/tensorpack/train/base.py
@@ -155,6 +155,8 @@ class Trainer(object):
                     self.trigger_epoch()
             except StopTraining:
                 logger.info("Training was stopped.")
+            except KeyboardInterrupt:
+                logger.info("Detected Ctrl+C and shutdown training.")
             except:
                 raise
             finally:


### PR DESCRIPTION
This handles non-gradient-descent updates like batch-norm from
tfSlim and regularization losses by fetching the op-collections.