### PR TITLE
Add Livedata

### DIFF
--- a/examples/SimilarityLearning/mnist-embeddings.py
+++ b/examples/SimilarityLearning/mnist-embeddings.py
@@ -130,13 +130,17 @@ class SoftTripletModel(TripletModel):
         return symbf.soft_triplet_loss(a, p, n, scope="loss")
 
 
-def get_config(model):
+def get_config(model, algorithm_name):
     logger.auto_set_dir()
 
     dataset = model.get_data()
     steps_per_epoch = dataset.size()
 
     lr = symbf.get_scalar_var('learning_rate', 1e-4, summary=True)
+
+    extra_display = ["cost"]
+    if not algorithm_name == "cosine":
+        extra_display = extra_display + ["loss/pos-dist", "loss/neg-dist"]
 
     return TrainConfig(
         dataflow=dataset,
@@ -148,7 +152,7 @@ def get_config(model):
         ],
         extra_callbacks=[
             MovingAverageSummary(),
-            ProgressBar(["cost", "loss/pos-dist", "loss/neg-dist"]),
+            ProgressBar(extra_display),
             StatPrinter()],
         steps_per_epoch=steps_per_epoch,
         max_epoch=20,
@@ -218,7 +222,7 @@ if __name__ == '__main__':
         if FLAGS.visualize:
             visualize(FLAGS.load, ALGO_CONFIGS[FLAGS.algorithm])
         else:
-            config = get_config(ALGO_CONFIGS[FLAGS.algorithm])
+            config = get_config(ALGO_CONFIGS[FLAGS.algorithm], FLAGS.algorithm)
             if FLAGS.load:
                 config.session_init = SaverRestore(FLAGS.load)
             else:

--- a/examples/SimilarityLearning/mnist-embeddings.py
+++ b/examples/SimilarityLearning/mnist-embeddings.py
@@ -77,7 +77,7 @@ class SiameseModel(EmbeddingModel):
             tf.identity(self.embed(inputs[0]), name="emb")
 
         # compute the actual loss
-        cost, pos_dist, neg_dist = symbf.contrastive_loss(x, y, label, 5., extra=True)
+        cost, pos_dist, neg_dist = symbf.contrastive_loss(x, y, label, 5., extra=True, scope="loss")
         self.cost = tf.identity(cost, name="cost")
 
         # track these values during training
@@ -92,7 +92,7 @@ class CosineModel(SiameseModel):
         with tf.variable_scope(tf.get_variable_scope(), reuse=True):
             tf.identity(self.embed(inputs[0]), name="emb")
 
-        cost = symbf.cosine_loss(x, y, label)
+        cost = symbf.cosine_loss(x, y, label, scope="loss")
         self.cost = tf.identity(cost, name="cost")
         add_moving_summary(self.cost)
 
@@ -110,7 +110,7 @@ class TripletModel(EmbeddingModel):
                 InputVar(tf.float32, (None, 28, 28), 'input_n')]
 
     def loss(self, a, p, n):
-        return symbf.triplet_loss(a, p, n, 5., extra=True)
+        return symbf.triplet_loss(a, p, n, 5., extra=True, scope="loss")
 
     def _build_graph(self, inputs):
         a, p, n = inputs
@@ -120,13 +120,14 @@ class TripletModel(EmbeddingModel):
             tf.identity(self.embed(inputs[0]), name="emb")
 
         cost, pos_dist, neg_dist = self.loss(a, p, n)
+
         self.cost = tf.identity(cost, name="cost")
         add_moving_summary(pos_dist, neg_dist, self.cost)
 
 
 class SoftTripletModel(TripletModel):
     def loss(self, a, p, n):
-        return symbf.soft_triplet_loss(a, p, n)
+        return symbf.soft_triplet_loss(a, p, n, scope="loss")
 
 
 def get_config(model):
@@ -145,6 +146,10 @@ def get_config(model):
             ModelSaver(),
             ScheduledHyperParamSetter('learning_rate', [(10, 1e-5), (20, 1e-6)])
         ],
+        extra_callbacks=[
+            MovingAverageSummary(),
+            ProgressBar(["cost", "loss/pos-dist", "loss/neg-dist"]),
+            StatPrinter()],
         steps_per_epoch=steps_per_epoch,
         max_epoch=20,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 six
 termcolor
-tqdm>4.6.1
+tqdm>4.11.1
 msgpack-python
 msgpack-numpy
 pyzmq

--- a/tensorpack/tfutils/symbolic_functions.py
+++ b/tensorpack/tfutils/symbolic_functions.py
@@ -213,7 +213,7 @@ def saliency_map(output, input, name="saliency_map"):
     return saliency_op
 
 
-def contrastive_loss(left, right, y, margin, extra=False):
+def contrastive_loss(left, right, y, margin, extra=False, scope="constrastive_loss"):
     r"""Loss for Siamese networks as described in the paper:
     `Learning a Similarity Metric Discriminatively, with Application to Face
     Verification <http://yann.lecun.com/exdb/publis/pdf/chopra-05.pdf>`_ by Chopra et al.
@@ -231,7 +231,7 @@ def contrastive_loss(left, right, y, margin, extra=False):
     Returns:
         tf.Tensor: constrastive_loss (averaged over the batch), (and optionally average_pos_dist, average_neg_dist)
     """
-    with tf.name_scope("constrastive_loss"):
+    with tf.name_scope(scope):
         y = tf.cast(y, tf.float32)
 
         delta = tf.reduce_sum(tf.square(left - right), 1)
@@ -256,7 +256,7 @@ def contrastive_loss(left, right, y, margin, extra=False):
             return loss
 
 
-def cosine_loss(left, right, y):
+def cosine_loss(left, right, y, scope="cosine_loss"):
     r"""Loss for Siamese networks (cosine version).
     Same as :func:`contrastive_loss` but with different similarity measurment.
 
@@ -280,14 +280,14 @@ def cosine_loss(left, right, y):
         with tf.name_scope("l2_norm"):
             return tf.sqrt(tf.reduce_sum(tf.square(t), 1) + eps)
 
-    with tf.name_scope("cosine_loss"):
+    with tf.name_scope(scope):
         y = 2 * tf.cast(y, tf.float32) - 1
         pred = tf.reduce_sum(left * right, 1) / (l2_norm(left) * l2_norm(right) + 1e-10)
 
         return tf.nn.l2_loss(y - pred) / tf.cast(tf.shape(left)[0], tf.float32)
 
 
-def triplet_loss(anchor, positive, negative, margin, extra=False):
+def triplet_loss(anchor, positive, negative, margin, extra=False, scope="triplet_loss"):
     r"""Loss for Triplet networks as described in the paper:
     `FaceNet: A Unified Embedding for Face Recognition and Clustering
     <https://arxiv.org/abs/1503.03832>`_
@@ -312,7 +312,7 @@ def triplet_loss(anchor, positive, negative, margin, extra=False):
         tf.Tensor: triplet-loss as scalar (and optionally average_pos_dist, average_neg_dist)
     """
 
-    with tf.name_scope("triplet_loss"):
+    with tf.name_scope(scope):
         d_pos = tf.reduce_sum(tf.square(anchor - positive), 1)
         d_neg = tf.reduce_sum(tf.square(anchor - negative), 1)
 
@@ -326,7 +326,7 @@ def triplet_loss(anchor, positive, negative, margin, extra=False):
             return loss
 
 
-def soft_triplet_loss(anchor, positive, negative, extra=True):
+def soft_triplet_loss(anchor, positive, negative, extra=True, scope="soft_triplet_loss"):
     """Loss for triplet networks as described in the paper:
     `Deep Metric Learning using Triplet Network
     <https://arxiv.org/abs/1412.6622>`_ by Hoffer et al.
@@ -345,7 +345,7 @@ def soft_triplet_loss(anchor, positive, negative, extra=True):
     """
 
     eps = 1e-10
-    with tf.name_scope("soft_triplet_loss"):
+    with tf.name_scope(scope):
         d_pos = tf.sqrt(tf.reduce_sum(tf.square(anchor - positive), 1) + eps)
         d_neg = tf.sqrt(tf.reduce_sum(tf.square(anchor - negative), 1) + eps)
 


### PR DESCRIPTION
![livemeter](https://cloud.githubusercontent.com/assets/6756603/21718163/cc1e1808-d415-11e6-8dd4-96356ebc4ced.png)
Sometimes it is necessary to inspect scalar values within an epoch.
This commit replaces tqdm with a modification to support livedata.

This should also be benchmarked a large-scale models. In simple MNIST examples I get no significant overhead.