### PR TITLE
Add continous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,49 @@
-language: "python"
-python:
-   - "2.7"
-   - "3.5"
 sudo: false
-cache: pip
+dist: "trusty"
+language: "python"
+
+cache:
+  pip: true
+  apt: true
+
+addons:
+    apt:
+        sources:
+            ubuntu-toolchain-r-test
+matrix:
+    fast_finish: true
+    include:
+        - os: linux
+          python: 2.7
+          env: TF_VERSION=0.12.1 TF_TYPE=release
+        - os: linux
+          python: 3.5
+          env: TF_VERSION=0.12.1 TF_TYPE=release
+        - os: linux
+          python: 2.7
+          env: TF_VERSION=0.12.1 TF_TYPE=nightly
+        - os: linux
+          python: 3.5
+          env: TF_VERSION=0.12.1 TF_TYPE=nightly
+    allow_failures:
+        - env: TF_VERSION=0.12.1 TF_TYPE=nightly
 
 install:
-  - pip install flake8
+    - echo $TRAVIS_PYTHON_VERSION
+    - pip install -U flake8 opencv-python
+    - if [ -e requirements.txt ]; then pip install -r requirements.txt;else pip install -r requirements.pip;fi
+    - ./tests/install-tensorflow.sh
 
 before_script:
-  - flake8 --version
+    - flake8 --version
+    - python -c "import cv2; print('OpenCV '+ cv2.__version__)"
+    - python -c "import tensorflow as tf; print('TensorFlow '+ tf.__version__)"
 
 script:
-  - flake8 .
-  - cd examples && flake8 .
+    - flake8 .
+    - cd examples && flake8 .
+    - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
+    - cd $TRAVIS_BUILD_DIR && python tests/test_examples.py
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tensorpack
+[![Build Status](https://travis-ci.org/ppwwyyxx/tensorpack.svg?branch=master)](https://travis-ci.org/ppwwyyxx/tensorpack)
 Neural Network Toolbox on TensorFlow
 
 Docs & tutorials should be ready within a month. See some [examples](examples) to learn about the framework:

--- a/tests/install-tensorflow.sh
+++ b/tests/install-tensorflow.sh
@@ -1,0 +1,26 @@
+if [ $TF_TYPE == "release" ]; then
+  if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then 
+		TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-${TF_VERSION}-cp27-none-linux_x86_64.whl
+	fi
+	if [[ $TRAVIS_PYTHON_VERSION == 3.4* ]]; then 
+		TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-${TF_VERSION}-cp34-cp34m-linux_x86_64.whl
+	fi
+	if [[ $TRAVIS_PYTHON_VERSION == 3.5* ]]; then 
+		TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-${TF_VERSION}-cp35-cp35m-linux_x86_64.whl
+	fi
+fi
+if [ $TF_TYPE == "nightly" ]; then
+	if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then 
+		TF_BINARY_URL=https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-${TF_VERSION}-cp27-none-linux_x86_64.whl
+	
+	fi
+	if [[ $TRAVIS_PYTHON_VERSION == 3.4* ]]; then 
+		TF_BINARY_URL=https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-${TF_VERSION}-cp34-cp34m-linux_x86_64.whl
+	fi
+	if [[ $TRAVIS_PYTHON_VERSION == 3.5* ]]; then 
+		TF_BINARY_URL=https://ci.tensorflow.org/view/Nightly/job/nightly-python35-linux-cpu/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-${TF_VERSION}-cp35-cp35m-linux_x86_64.whl
+	fi
+fi
+
+
+pip install  --upgrade ${TF_BINARY_URL}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# File: test_examples.py
+# Author: Patrick Wieschollek <mail@patwie.com>
+
+import sys
+import subprocess
+import shlex
+import threading
+from termcolor import colored, cprint
+
+
+COMMANDS_TO_TEST = ["python examples/mnist-convnet.py"]
+
+
+class SurviveException(Exception):
+    """Exception when process is already terminated
+    """
+    pass
+
+
+class PythonScript(threading.Thread):
+    """A wrapper to start a python script with timeout.
+
+    To test the actual models even without GPUs we simply start them and
+    test whether they survive a certain amount of time "timeout". This allows to
+    test if all imports are correct and the computation graph can be built without
+    run the entire model on the CPU.
+
+    Attributes:
+        cmd (str): command to execute the example with all flags (including python)
+        p: process handle
+        timeout (int): timeout in seconds
+    """
+    def __init__(self, cmd, timeout=10):
+        """Prepare a python script
+
+        Args:
+            cmd (TYPE): command to execute the example with all flags (including python)
+            timeout (int, optional): time in seconds the script has to survive
+        """
+        threading.Thread.__init__(self)
+        self.cmd = cmd
+        self.timeout = timeout
+
+    def run(self):
+        self.p = subprocess.Popen(shlex.split(self.cmd), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        self.out, self.err = self.p.communicate()
+
+    def execute(self):
+        """Execute python script in other process.
+
+        Raises:
+            SurviveException: contains the error message of the script if it terminated before timeout
+        """
+        self.start()
+        self.join(self.timeout)
+
+        if self.is_alive():
+            self.p.terminate()
+            self.p.kill()  # kill -9
+            self.join()
+        else:
+            # something unexpected happend here, this script was supposed to survive at leat the timeout
+            if len(self.err) is not 0:
+                stderr = "\n".join([" " * 10 + v for v in self.err.split("\n")])
+                raise SurviveException(stderr)
+
+
+examples_total = len(COMMANDS_TO_TEST)
+examples_passed = 0
+examples_failed = []
+max_name_length = max([len(v) for v in COMMANDS_TO_TEST]) + 10
+
+cprint("Test %i python scripts with timeout" % (examples_total), 'yellow', attrs=['bold'])
+
+for example_name in COMMANDS_TO_TEST:
+    string = "test: %s %s" % (example_name, " " * (max_name_length - len(example_name)))
+    sys.stdout.write(colored(string, 'yellow', attrs=['bold']))
+    try:
+        PythonScript(example_name).execute()
+        cprint("... works", 'green', attrs=['bold'])
+        examples_passed += 1
+    except Exception as stderr_message:
+        cprint("... examples_failed", 'red', attrs=['bold'])
+        print(stderr_message)
+        examples_failed.append(example_name)
+
+print("\n\n")
+cprint("Summary:    TEST examples_passed %i / %i" % (examples_passed, examples_total), 'yellow', attrs=['bold'])
+if examples_total != examples_passed:
+    print("The following script examples_failed:")
+    for failed_script in examples_failed:
+        print("  - %s" % failed_script)
+    sys.exit(1)
+else:
+    sys.exit(0)


### PR DESCRIPTION
Use Travis-CI to run some tests under the latest release of TensorFlow and nightly releases in python 2.7 and 3.5.

This is a clean version of #93, which cannot be opened again because of rebasing to master.

features:
- TensorFlow version is environment variable
- run tests with the latest nightly build of the current version to check changes in API (these are allowed to fail)
- run arbitrary Python scripts with a timeout to test imports

for output see:
https://travis-ci.org/ppwwyyxx/tensorpack/builds/191097681

This further allows to:
- add tests for dataflow from this lib
- add python [unit-tests](https://docs.python.org/2/library/unittest.html)
- automatically [deploy Sphinx-doc](https://drdoctr.github.io/doctr/)
- automatically [deploy pip package](http://5minutes.youkidea.com/howto-deploy-python-package-on-pypi-with-github-and-travis.html)

It might also be possible to cache the MNIST dataset actually to run the example (including the computation graph). I doubt that this is no possible at the moment within the current timeout settings as it has to download the dataset.