### PR TITLE
start auto deploy to pypip using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,16 @@ notifications:
       - ppwwyyxxc@gmail.com
     on_success: never
     on_failure: change # default: always
+
+# upload current version from release branch automatically
+deploy:
+  provider: pypi
+  user: tensorpack-deploy
+  distributions: sdist bdist_egg bdist_wheel
+  password:
+    # @p please change this ppwwyyxxc
+    secure: b4f6y1xw5B/RXXnOu6JIaNcgOBZ0/CkNaMeEXsoQSewYZNwobLPYA
+  on:
+    tags: true
+    repo: ppwwyyxxc/tensorpack
+    condition: "$TF_VERSION=1.0.0rc0 $TF_TYPE=release"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = tensorpack
+author = TensorPack contributors
+author-email = ppwwyyxxc@gmail.com
+summary = Neural Network Toolbox on TensorFlow
+description-file = README.md
+home-page = https://github.com/ppwwyyxx/tensorpack
+
+
+[files]
+packages =
+    tensorpack
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
+    pbr=True,
+)


### PR DESCRIPTION
Next steps:

install ruby to encrypt the pypip -password
--------------
https://gorails.com/setup/ubuntu/16.04:

or copy-paste

    sudo apt-get update
    sudo apt-get install -yy git-core curl zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev python-software-properties libffi-dev nodejs

    cd
    git clone https://github.com/rbenv/rbenv.git ~/.rbenv
    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
    echo 'eval "$(rbenv init -)"' >> ~/.bashrc
    exec $SHELL

    git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
    echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bashrc
    exec $SHELL

    rbenv install 2.4.0
    rbenv global 2.4.0
    ruby -v

    gem install travis # no need for bundler


Test pip locally:
-------------------

        virtualenv --clear -q -p python2.7 venv
        virtualenv venv
        source venv/bin/activate
        cd tensorpack-dir
        python setup.py sdist bdist_egg bdist_wheel
        pip install -e .

Encrypt pypip-password:

        cd tensorpack-dir
        travis encrypt --add deploy.password


This should solve #88 and is based on:
- https://docs.travis-ci.com/user/deployment/pypi/
- http://www.dougalmatthews.com/2016/Sep/01/automate-publishing-to-pypi-with-pbr-and-travis/

which should automatically bump the version number.

But this might have some consequences how to handle the git. Maybe a release branch would be helpful -- or everybody is using an extra branch :wink: before merging to make sure the master branch always pass the tests.