### PR TITLE
LMDB fix

### DIFF
--- a/tensorpack/dataflow/format.py
+++ b/tensorpack/dataflow/format.py
@@ -3,6 +3,7 @@
 # Author: Yuxin Wu <ppwwyyxxc@gmail.com>
 
 import numpy as np
+import six
 from six.moves import range
 import os
 
@@ -100,7 +101,7 @@ class LMDBData(RNGDataFlow):
                     self.keys = find_keys(self._txn, self._size)
             else:
                 # check if key-format like '{:0>8d}' was given
-                if isinstance(key_format, basestring):
+                if isinstance(key_format, six.string_types):
                     self.keys = map(lambda x: key_format.format(x), list(np.arange(self._size)))
                 else:
                     self.keys = key_format

--- a/tensorpack/dataflow/format.py
+++ b/tensorpack/dataflow/format.py
@@ -106,6 +106,7 @@ class LMDBData(RNGDataFlow):
 
     def reset_state(self):
         super(LMDBData, self).reset_state()
+        self.open_lmdb(self.keys)
 
     def size(self):
         return self._size
@@ -118,8 +119,6 @@ class LMDBData(RNGDataFlow):
                 if k != '__keys__':
                     yield [k, v]
         else:
-            if not hasattr(self, "rng"):
-                self.reset_state()
             self.rng.shuffle(self.keys)
             for k in self.keys:
                 v = self._txn.get(k)


### PR DESCRIPTION
I downloaded ImageNet and converted it into lmdb directly from the tar-files.

Here, I noticed that CaffeLMDB is very slow because its needs to gather the keys by traversing over all 1.2M entries. Here, this would take >35min for ILSVRC2012_img_train.lmdb **during** preparing things.

Now, it is possible to specify the `key_format`, such that there is no overhead anymore and the keys will be generated without any noticeable overhead. Note, the size is already known.

Changes:
- use key_format to generate keys
- remove lmdb_open in reset-state (was open db twice)
- msgpack raised an exception, which is now catched


I can use 
````python
from tensorpack import *

ds = CaffeLMDB('/data/imageNet/ILSVRC2012/lmdb/train', key_format='{:0>8d}')
ds = TestDataSpeed(ds)
ds.start_test()
````
and it will start immediately.


@ppwwyyxx at some point `self.reset_state()` is mixed up in your implementation. I sometimes get `class has no attribute rng` when using MNIST or another dataset.