### PR TITLE
fix typo `asypte` and remove casting error

### DIFF
--- a/tensorpack/dataflow/imgaug/imgproc.py
+++ b/tensorpack/dataflow/imgaug/imgproc.py
@@ -228,4 +228,6 @@ class Lighting(ImageAugmentor):
         v = v.reshape((3, 1))
         inc = np.dot(self.eigvec, v).reshape((3,))
         img = np.add(img, inc)
+        if old_dtype == np.uint8:
+            img = np.clip(img, 0, 255)
         return img.astype(old_dtype)

--- a/tensorpack/dataflow/imgaug/imgproc.py
+++ b/tensorpack/dataflow/imgaug/imgproc.py
@@ -54,7 +54,7 @@ class Brightness(ImageAugmentor):
         img += v
         if self.clip or old_dtype == np.uint8:
             img = np.clip(img, 0, 255)
-        return img.asypte(old_dtype)
+        return img.astype(old_dtype)
 
 
 class Contrast(ImageAugmentor):
@@ -227,5 +227,5 @@ class Lighting(ImageAugmentor):
         v = v * self.eigval
         v = v.reshape((3, 1))
         inc = np.dot(self.eigvec, v).reshape((3,))
-        img += inc
+        img = np.add(img, inc)
         return img.astype(old_dtype)


### PR DESCRIPTION
The current master branch gives
````
[0209 15:59:02 @image.py:74] ERR Got 9 augmentation errors.
Traceback (most recent call last):
  File "/home/patwie/git/tensorpack/tensorpack/dataflow/image.py", line 68, in func
    ret = self.augs.augment(x)
  File "/home/patwie/git/tensorpack/tensorpack/dataflow/imgaug/base.py", line 76, in augment
    img, params = self._augment_return_params(img)
  File "/home/patwie/git/tensorpack/tensorpack/dataflow/imgaug/base.py", line 105, in _augment_return_params
    img, prm = a._augment_return_params(img)
  File "/home/patwie/git/tensorpack/tensorpack/dataflow/imgaug/base.py", line 42, in _augment_return_params
    return (self._augment(d, prms), prms)
  File "/home/patwie/git/tensorpack/tensorpack/dataflow/imgaug/meta.py", line 113, in _augment
    img = self.aug_lists[k]._augment(img, prms[k])
  File "/home/patwie/git/tensorpack/tensorpack/dataflow/imgaug/imgproc.py", line 230, in _augment
    img += inc
TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('uint8') with casting rule 'same_kind'
Prefetch process exited.
Prefetch process exited.


````