### PR TITLE
Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
 script:
 - flake8 .
 - cd examples && flake8 .
-- mkdir $HOME/tensorpack_data
+- mkdir -p $HOME/tensorpack_data
 - export TENSORPACK_DATASET=$HOME/tensorpack_data
 - cd $TRAVIS_BUILD_DIR/tests && python run.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: python
 cache:
   pip: true
   apt: true
+  directories:
+    - $HOME/tensorpack_data
 
 addons:
   apt:
@@ -45,7 +47,9 @@ before_script:
 script:
 - flake8 .
 - cd examples && flake8 .
-- cd $TRAVIS_BUILD_DIR && python tests/test_examples.py
+- mkdir $HOME/tensorpack_data
+- export TENSORPACK_DATASET=$HOME/tensorpack_data
+- cd $TRAVIS_BUILD_DIR/tests && python run.py
 
 notifications:
 - email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
   apt:
     packages:
     - pandoc
+    - libprotobuf-dev
+    - protobuf-compiler
 
 matrix:
   fast_finish: true
@@ -49,7 +51,7 @@ script:
 - cd examples && flake8 .
 - mkdir -p $HOME/tensorpack_data
 - export TENSORPACK_DATASET=$HOME/tensorpack_data
-- cd $TRAVIS_BUILD_DIR/tests && python run.py
+- cd $TRAVIS_BUILD_DIR/tests && python -m unittest discover -v
 
 notifications:
 - email:

--- a/examples/ResNet/imagenet-resnet.py
+++ b/examples/ResNet/imagenet-resnet.py
@@ -123,8 +123,9 @@ class Model(ModelDesc):
         return tf.train.MomentumOptimizer(lr, 0.9, use_nesterov=True)
 
 
-def get_data(train_or_test):
-    # return FakeData([[64, 224,224,3],[64]], 1000, random=False, dtype='uint8')
+def get_data(train_or_test, fake=False):
+    if fake:
+        return FakeData([[64, 224,224,3],[64]], 1000, random=False, dtype='uint8')
     isTrain = train_or_test == 'train'
 
     datadir = args.data
@@ -187,9 +188,9 @@ def get_data(train_or_test):
     return ds
 
 
-def get_config():
-    dataset_train = get_data('train')
-    dataset_val = get_data('val')
+def get_config(fake=False):
+    dataset_train = get_data('train', fake=fake)
+    dataset_val = get_data('val', fake=fake)
 
     return TrainConfig(
         dataflow=dataset_train,
@@ -231,6 +232,8 @@ if __name__ == '__main__':
     parser.add_argument('--gpu', help='comma separated list of GPU(s) to use.')
     parser.add_argument('--data', help='ILSVRC dataset dir')
     parser.add_argument('--load', help='load model')
+    parser.add_argument('--fake', help='use fakedata to test or benchmark this model',
+                        type=bool, default=False)
     parser.add_argument('-d', '--depth', help='resnet depth',
                         type=int, default=18, choices=[18, 34, 50, 101])
     parser.add_argument('--eval', action='store_true')
@@ -249,7 +252,7 @@ if __name__ == '__main__':
     BATCH_SIZE = TOTAL_BATCH_SIZE // NR_GPU
 
     logger.auto_set_dir()
-    config = get_config()
+    config = get_config(args.fake)
     if args.load:
         config.session_init = SaverRestore(args.load)
     config.nr_tower = NR_GPU

--- a/examples/ResNet/imagenet-resnet.py
+++ b/examples/ResNet/imagenet-resnet.py
@@ -237,8 +237,7 @@ if __name__ == '__main__':
     parser.add_argument('--gpu', help='comma separated list of GPU(s) to use.')
     parser.add_argument('--data', help='ILSVRC dataset dir')
     parser.add_argument('--load', help='load model')
-    parser.add_argument('--fake', help='use fakedata to test or benchmark this model',
-                        type=bool, default=False)
+    parser.add_argument('--fake', help='use fakedata to test or benchmark this model', action='store_true')
     parser.add_argument('--data_format', help='specify NCHW or NHWC',
                         type=str, default='NCHW')
     parser.add_argument('-d', '--depth', help='resnet depth',

--- a/examples/SimilarityLearning/mnist-embeddings.py
+++ b/examples/SimilarityLearning/mnist-embeddings.py
@@ -6,10 +6,6 @@
 import numpy as np
 import os
 
-import matplotlib
-from matplotlib import offsetbox
-import matplotlib.pyplot as plt
-
 from tensorpack import *
 import tensorpack.tfutils.symbolic_functions as symbf
 from tensorpack.tfutils.summary import add_moving_summary
@@ -19,6 +15,15 @@ from tensorflow.python.platform import flags
 import tensorflow.contrib.slim as slim
 
 from embedding_data import get_test_data, MnistPairs, MnistTriplets
+
+MATPLOTLIB_AVAIBLABLE = False
+try:
+    import matplotlib
+    from matplotlib import offsetbox
+    import matplotlib.pyplot as plt
+    MATPLOTLIB_AVAIBLABLE = True
+except ImportError:
+    MATPLOTLIB_AVAIBLABLE = False
 
 
 FLAGS = flags.FLAGS
@@ -162,6 +167,9 @@ def get_config(model, algorithm_name):
 
 
 def visualize(model_path, model):
+    if not MATPLOTLIB_AVAIBLABLE:
+        logger.error("visualize requires matplotlib package ...")
+        return
     pred = OfflinePredictor(PredictConfig(
         session_init=get_model_loader(model_path),
         model=model(),

--- a/tests/case_script.py
+++ b/tests/case_script.py
@@ -51,7 +51,7 @@ class PythonScript(threading.Thread):
         else:
             # something unexpected happend here, this script was supposed to survive at leat the timeout
             if len(self.err) is not 0:
-                stderr = "\n".join([" " * 10 + v for v in self.err.split("\n")])
+                stderr = "\n".join([" " * 10 + str(v) for v in self.err.split("\n")])
                 raise AssertionError(stderr)
 
 

--- a/tests/case_script.py
+++ b/tests/case_script.py
@@ -2,6 +2,7 @@ from abc import abstractproperty
 import unittest
 import subprocess
 import shlex
+import sys
 import threading
 import os
 import shutil
@@ -69,7 +70,7 @@ class TestPythonScript(unittest.TestCase):
             shutil.rmtree(os.path.join("train_log", script))
 
     def assertSurvive(self, script, args=None, timeout=10):  # noqa
-        cmd = "python " + script
+        cmd = "python{} {}".format(sys.version_info.major, script)
         if args:
             cmd += " " + " ".join(args)
         PythonScript(cmd, timeout=timeout).execute()

--- a/tests/case_script.py
+++ b/tests/case_script.py
@@ -1,3 +1,4 @@
+from abc import abstractproperty
 import unittest
 import subprocess
 import shlex
@@ -56,6 +57,10 @@ class PythonScript(threading.Thread):
 
 class TestPythonScript(unittest.TestCase):
 
+    @abstractproperty
+    def script(self):
+        pass
+
     @staticmethod
     def clear_trainlog(script):
         script = os.path.basename(script)
@@ -68,3 +73,9 @@ class TestPythonScript(unittest.TestCase):
         if args:
             cmd += " " + " ".join(args)
         PythonScript(cmd, timeout=timeout).execute()
+
+    def setUp(self):
+        TestPythonScript.clear_trainlog(self.script)
+
+    def tearDown(self):
+        TestPythonScript.clear_trainlog(self.script)

--- a/tests/case_script.py
+++ b/tests/case_script.py
@@ -51,7 +51,7 @@ class PythonScript(threading.Thread):
         else:
             # something unexpected happend here, this script was supposed to survive at leat the timeout
             if len(self.err) is not 0:
-                stderr = "\n".join([" " * 10 + str(v) for v in self.err.split("\n")])
+                stderr = "\n".join([" " * 10 + v for v in self.err.decode("utf-8").split("\n")])
                 raise AssertionError(stderr)
 
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,5 @@
+import unittest
+
+if __name__ == '__main__':
+    testsuite = unittest.TestLoader().discover('.')
+    unittest.TextTestRunner(verbosity=2).run(testsuite)

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,5 +1,0 @@
-import unittest
-
-if __name__ == '__main__':
-    testsuite = unittest.TestLoader().discover('.')
-    unittest.TextTestRunner(verbosity=2).run(testsuite)

--- a/tests/test_char_rnn.py
+++ b/tests/test_char_rnn.py
@@ -1,0 +1,27 @@
+from case_script import TestPythonScript
+import os
+
+
+def random_content():
+    return ('Lorem ipsum dolor sit amet\n'
+            'consetetur sadipscing elitr\n'
+            'sed diam nonumy eirmod tempor invidunt ut labore\n')
+
+
+class CharRNNTest(TestPythonScript):
+
+    @property
+    def script(self):
+        return '../examples/GAN/InfoGAN-mnist.py'
+
+    def setUp(self):
+        super(CharRNNTest, self).setUp()
+        with open('input.txt', 'w') as f:
+            f.write(random_content())
+
+    def test(self):
+        self.assertSurvive(self.script, args=None, timeout=10)
+
+    def tearDown(self):
+        super(CharRNNTest, self).tearDown()
+        os.remove('input.txt')

--- a/tests/test_char_rnn.py
+++ b/tests/test_char_rnn.py
@@ -12,7 +12,7 @@ class CharRNNTest(TestPythonScript):
 
     @property
     def script(self):
-        return '../examples/GAN/InfoGAN-mnist.py'
+        return '../examples/Char-RNN/char-rnn.py'
 
     def setUp(self):
         super(CharRNNTest, self).setUp()
@@ -20,7 +20,7 @@ class CharRNNTest(TestPythonScript):
             f.write(random_content())
 
     def test(self):
-        self.assertSurvive(self.script, args=None, timeout=10)
+        self.assertSurvive(self.script, args=['--gpu 0', 'train'], timeout=10)
 
     def tearDown(self):
         super(CharRNNTest, self).tearDown()

--- a/tests/test_infogan.py
+++ b/tests/test_infogan.py
@@ -3,11 +3,9 @@ from case_script import TestPythonScript
 
 class InfoGANTest(TestPythonScript):
 
-    def setUp(self):
-        TestPythonScript.clear_trainlog('../examples/GAN/InfoGAN-mnist.py')
+    @property
+    def script(self):
+        return '../examples/mnist-convnet.py'
 
-    def testScript(self):
-        self.assertSurvive('../examples/GAN/InfoGAN-mnist.py', args=None, timeout=10)
-
-    def tearDown(self):
-        TestPythonScript.clear_trainlog('../examples/GAN/InfoGAN-mnist.py')
+    def test(self):
+        self.assertSurvive(self.script, args=None, timeout=10)

--- a/tests/test_infogan.py
+++ b/tests/test_infogan.py
@@ -5,7 +5,7 @@ class InfoGANTest(TestPythonScript):
 
     @property
     def script(self):
-        return '../examples/mnist-convnet.py'
+        return '../examples/GAN/InfoGAN-mnist.py'
 
     def test(self):
         self.assertSurvive(self.script, args=None, timeout=10)

--- a/tests/test_infogan.py
+++ b/tests/test_infogan.py
@@ -1,0 +1,13 @@
+from case_script import TestPythonScript
+
+
+class InfoGANTest(TestPythonScript):
+
+    def setUp(self):
+        TestPythonScript.clear_trainlog('../examples/GAN/InfoGAN-mnist.py')
+
+    def testScript(self):
+        self.assertSurvive('../examples/GAN/InfoGAN-mnist.py', args=None, timeout=10)
+
+    def tearDown(self):
+        TestPythonScript.clear_trainlog('../examples/GAN/InfoGAN-mnist.py')

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -6,7 +6,7 @@ class MnistTest(TestPythonScript):
     def setUp(self):
         TestPythonScript.clear_trainlog('../examples/mnist-convnet.py')
 
-    def testMnistScript(self):
+    def testScript(self):
         self.assertSurvive('../examples/mnist-convnet.py', args=None, timeout=10)
 
     def tearDown(self):

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -1,0 +1,13 @@
+from case_script import TestPythonScript
+
+
+class MnistTest(TestPythonScript):
+
+    def setUp(self):
+        TestPythonScript.clear_trainlog('../examples/mnist-convnet.py')
+
+    def testMnistScript(self):
+        self.assertSurvive('../examples/mnist-convnet.py', args=None, timeout=10)
+
+    def tearDown(self):
+        TestPythonScript.clear_trainlog('../examples/mnist-convnet.py')

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -3,11 +3,9 @@ from case_script import TestPythonScript
 
 class MnistTest(TestPythonScript):
 
-    def setUp(self):
-        TestPythonScript.clear_trainlog('../examples/mnist-convnet.py')
+    @property
+    def script(self):
+        return '../examples/mnist-convnet.py'
 
-    def testScript(self):
-        self.assertSurvive('../examples/mnist-convnet.py', args=None, timeout=10)
-
-    def tearDown(self):
-        TestPythonScript.clear_trainlog('../examples/mnist-convnet.py')
+    def test(self):
+        self.assertSurvive(self.script, args=None, timeout=10)

--- a/tests/test_mnist_similarity.py
+++ b/tests/test_mnist_similarity.py
@@ -1,0 +1,11 @@
+from case_script import TestPythonScript
+
+
+class SimilarityLearningTest(TestPythonScript):
+
+    @property
+    def script(self):
+        return '../examples/SimilarityLearning/mnist-embeddings.py'
+
+    def test(self):
+        self.assertSurvive(self.script, args=['--algorithm triplet'], timeout=10)

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -3,6 +3,59 @@ import os
 import numpy as np
 import cv2
 import shutil
+import tarfile
+import errno
+from six.moves import urllib
+import sys
+
+
+CAFFE_ILSVRC12_URL = "http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz"
+
+
+# this is duplicated code, but this file should be self-contained
+def mkdir_p(dirname):
+    """ Make a dir recursively, but do nothing if the dir exists
+
+    Args:
+        dirname(str):
+    """
+    assert dirname is not None
+    if dirname == '' or os.path.isdir(dirname):
+        return
+    try:
+        os.makedirs(dirname)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise e
+
+
+# this is duplicated code, but this file should be self-contained
+def download(url, dir):
+    """
+    Download URL to a directory. Will figure out the filename automatically
+    from URL.
+    """
+    mkdir_p(dir)
+    fname = url.split('/')[-1]
+    fpath = os.path.join(dir, fname)
+
+    def _progress(count, block_size, total_size):
+        sys.stdout.write('\r>> Downloading %s %.1f%%' %
+                         (fname,
+                             min(float(count * block_size) / total_size,
+                                 1.0) * 100.0))
+        sys.stdout.flush()
+    try:
+        fpath, _ = urllib.request.urlretrieve(url, fpath, reporthook=_progress)
+        statinfo = os.stat(fpath)
+        size = statinfo.st_size
+    except Exception as e:
+        raise e
+    assert size > 0, "Download an empty file!"
+    sys.stdout.write('\n')
+    # TODO human-readable size
+    print('Succesfully downloaded ' + fname + " " + str(size) + ' bytes.')
+    return fpath
 
 
 def fake_ilsvrc12():
@@ -11,6 +64,7 @@ def fake_ilsvrc12():
         if not os.path.exists(n):
             os.mkdir(n)
 
+    # create directories
     mkdir('ilsvrc')
     mkdir('ilsvrc/train')
     mkdir('ilsvrc/train/n02134418')
@@ -20,6 +74,7 @@ def fake_ilsvrc12():
     mkdir('ilsvrc/val/n02134418')
     mkdir('ilsvrc/val/n02134419')
 
+    # image is some random noise
     def fake_image(shape=(255, 225, 3)):
         return np.random.randint(0, 255, shape)
 
@@ -28,6 +83,28 @@ def fake_ilsvrc12():
             fn = 'ilsvrc/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
             cv2.imwrite(fn, fake_image())
             cv2.imwrite('ilsvrc/val/n%s/n%s_%i.JPEG' % (subset, subset, i), fake_image())
+
+    # download caffe_ilsvrc12.tar.gz if not cached yet
+    tp_data_dir = os.path.join(os.environ['HOME'], 'tensorpack_data')
+    if not os.path.isfile(os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')):
+        fpath = download(CAFFE_ILSVRC12_URL, tp_data_dir)
+    else:
+        print('caffe_ilsvrc12.tar.gz already exists')
+        fpath = os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')
+    tarfile.open(fpath, 'r:gz').extractall('ilsvrc')
+
+    # the ILSVRC dataset class uses this file to get the image paths
+    with open('ilsvrc/train.txt', 'w') as f:
+        f.write('ILSVRC2012_train_00000000.JPEG 65\n')
+        f.write('ILSVRC2012_train_00000001.JPEG 65\n')
+
+    with open('ilsvrc/val.txt', 'w') as f:
+        f.write('ILSVRC2012_val_00000000.JPEG 65\n')
+        f.write('ILSVRC2012_val_00000001.JPEG 65\n')
+
+    with open('ilsvrc/test.txt', 'w') as f:
+        f.write('ILSVRC2012_test_00000000.JPEG 65\n')
+        f.write('ILSVRC2012_test_00000001.JPEG 65\n')
 
 
 class ResnetTest(TestPythonScript):

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -65,13 +65,13 @@ def fake_ilsvrc12():
             os.mkdir(n)
 
     # create directories
-    mkdir('ilsvrc')
-    mkdir('ilsvrc/train')
-    mkdir('ilsvrc/train/n02134418')
-    mkdir('ilsvrc/train/n02134419')
+    mkdir('ilsvrc_metadata')
+    mkdir('ilsvrc_metadata/train')
+    mkdir('ilsvrc_metadata/train/n02134418')
+    mkdir('ilsvrc_metadata/train/n02134419')
 
-    mkdir('ilsvrc/val')
-    mkdir('ilsvrc/test')
+    mkdir('ilsvrc_metadata/val')
+    mkdir('ilsvrc_metadata/test')
 
     # image is some random noise
     def fake_image(shape=(255, 225, 3)):
@@ -79,10 +79,10 @@ def fake_ilsvrc12():
 
     for subset in ['02134418', '02134419']:
         for i in range(2):
-            fn = 'ilsvrc/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
+            fn = 'ilsvrc_metadata/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
             cv2.imwrite(fn, fake_image())
-        cv2.imwrite('val/ILSVRC2012_val_%s.JPEG' % (subset), fake_image())
-        cv2.imwrite('test/ILSVRC2012_test_%s.JPEG' % (subset), fake_image())
+        cv2.imwrite('ilsvrc_metadata/val/ILSVRC2012_val_%s.JPEG' % (subset), fake_image())
+        cv2.imwrite('ilsvrc_metadata/test/ILSVRC2012_test_%s.JPEG' % (subset), fake_image())
 
     # download caffe_ilsvrc12.tar.gz if not cached yet
     tp_data_dir = os.path.join(os.environ['HOME'], 'tensorpack_data')
@@ -91,20 +91,20 @@ def fake_ilsvrc12():
     else:
         print('caffe_ilsvrc12.tar.gz already exists')
         fpath = os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')
-    tarfile.open(fpath, 'r:gz').extractall('ilsvrc')
+    tarfile.open(fpath, 'r:gz').extractall('ilsvrc_metadata')
 
     # the ILSVRC dataset class uses these files to get the image paths
-    with open('ilsvrc/train.txt', 'w') as f:
+    with open('ilsvrc_metadata/train.txt', 'w') as f:
         f.write('n02134418/n02134418_0.JPEG 0\n')
         f.write('n02134418/n02134418_1.JPEG 0\n')
         f.write('n02134419/n02134419_0.JPEG 0\n')
         f.write('n02134419/n02134419_1.JPEG 0\n')
 
-    with open('ilsvrc/val.txt', 'w') as f:
+    with open('ilsvrc_metadata/val.txt', 'w') as f:
         f.write('ILSVRC2012_val_02134418.JPEG 0\n')
         f.write('ILSVRC2012_val_02134419.JPEG 0\n')
 
-    with open('ilsvrc/test.txt', 'w') as f:
+    with open('ilsvrc_metadata/test.txt', 'w') as f:
         f.write('ILSVRC2012_test_02134418.JPEG 0\n')
         f.write('ILSVRC2012_test_02134419.JPEG 0\n')
 

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -1,7 +1,7 @@
 from case_script import TestPythonScript
 import os
-import numpy as np
-import cv2
+# import numpy as np
+# import cv2
 import shutil
 import tarfile
 import errno

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -1,88 +1,17 @@
 from case_script import TestPythonScript
 import os
-# import numpy as np
-# import cv2
 import shutil
 import tarfile
-import errno
-from six.moves import urllib
-import sys
+from tensorpack.utils.fs import download, mkdir_p
 
 
 CAFFE_ILSVRC12_URL = "http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz"
 
 
-# this is duplicated code, but this file should be self-contained
-def mkdir_p(dirname):
-    """ Make a dir recursively, but do nothing if the dir exists
-
-    Args:
-        dirname(str):
-    """
-    assert dirname is not None
-    if dirname == '' or os.path.isdir(dirname):
-        return
-    try:
-        os.makedirs(dirname)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise e
-
-
-# this is duplicated code, but this file should be self-contained
-def download(url, dir):
-    """
-    Download URL to a directory. Will figure out the filename automatically
-    from URL.
-    """
-    mkdir_p(dir)
-    fname = url.split('/')[-1]
-    fpath = os.path.join(dir, fname)
-
-    def _progress(count, block_size, total_size):
-        sys.stdout.write('\r>> Downloading %s %.1f%%' %
-                         (fname,
-                             min(float(count * block_size) / total_size,
-                                 1.0) * 100.0))
-        sys.stdout.flush()
-    try:
-        fpath, _ = urllib.request.urlretrieve(url, fpath, reporthook=_progress)
-        statinfo = os.stat(fpath)
-        size = statinfo.st_size
-    except Exception as e:
-        raise e
-    assert size > 0, "Download an empty file!"
-    sys.stdout.write('\n')
-    # TODO human-readable size
-    print('Succesfully downloaded ' + fname + " " + str(size) + ' bytes.')
-    return fpath
-
-
 def fake_ilsvrc12():
 
-    def mkdir(n):
-        if not os.path.exists(n):
-            os.mkdir(n)
-
     # create directories
-    mkdir('ilsvrc_metadata')
-    # mkdir('ilsvrc_metadata/train')
-    # mkdir('ilsvrc_metadata/train/n02134418')
-    # mkdir('ilsvrc_metadata/train/n02134419')
-
-    # mkdir('ilsvrc_metadata/val')
-    # mkdir('ilsvrc_metadata/test')
-
-    # # image is some random noise
-    # def fake_image(shape=(255, 225, 3)):
-    #     return np.random.randint(0, 255, shape)
-
-    # for subset in ['02134418', '02134419']:
-    #     for i in range(2):
-    #         fn = 'ilsvrc_metadata/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
-    #         cv2.imwrite(fn, fake_image())
-    #     cv2.imwrite('ilsvrc_metadata/val/ILSVRC2012_val_%s.JPEG' % (subset), fake_image())
-    #     cv2.imwrite('ilsvrc_metadata/test/ILSVRC2012_test_%s.JPEG' % (subset), fake_image())
+    mkdir_p('ilsvrc_metadata')
 
     # download caffe_ilsvrc12.tar.gz if not cached yet
     tp_data_dir = os.path.join(os.environ['HOME'], 'tensorpack_data')
@@ -92,21 +21,6 @@ def fake_ilsvrc12():
         print('caffe_ilsvrc12.tar.gz already exists')
         fpath = os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')
     tarfile.open(fpath, 'r:gz').extractall('ilsvrc_metadata')
-
-    # # the ILSVRC dataset class uses these files to get the image paths
-    # with open('ilsvrc_metadata/train.txt', 'w') as f:
-    #     f.write('n02134418/n02134418_0.JPEG 0\n')
-    #     f.write('n02134418/n02134418_1.JPEG 0\n')
-    #     f.write('n02134419/n02134419_0.JPEG 0\n')
-    #     f.write('n02134419/n02134419_1.JPEG 0\n')
-
-    # with open('ilsvrc_metadata/val.txt', 'w') as f:
-    #     f.write('ILSVRC2012_val_02134418.JPEG 0\n')
-    #     f.write('ILSVRC2012_val_02134419.JPEG 0\n')
-
-    # with open('ilsvrc_metadata/test.txt', 'w') as f:
-    #     f.write('ILSVRC2012_test_02134418.JPEG 0\n')
-    #     f.write('ILSVRC2012_test_02134419.JPEG 0\n')
 
 
 class ResnetTest(TestPythonScript):

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -120,7 +120,8 @@ class ResnetTest(TestPythonScript):
         fake_ilsvrc12()
 
     def test(self):
-        self.assertSurvive(self.script, args=['--data ilsvrc_metadata', '--gpu 0', '--fake True'], timeout=10)
+        self.assertSurvive(self.script, args=['--data ilsvrc_metadata',
+                                              '--gpu 0', '--fake True', '--data_format NHWC'], timeout=10)
 
     def tearDown(self):
         super(ResnetTest, self).tearDown()

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -1,0 +1,49 @@
+from case_script import TestPythonScript
+import os
+import numpy as np
+import cv2
+import shutil
+
+
+def fake_ilsvrc12():
+
+    def mkdir(n):
+        if not os.path.exists(n):
+            os.mkdir(n)
+
+    mkdir('ilsvrc')
+    mkdir('ilsvrc/train')
+    mkdir('ilsvrc/train/n02134418')
+    mkdir('ilsvrc/train/n02134419')
+
+    mkdir('ilsvrc/val')
+    mkdir('ilsvrc/val/n02134418')
+    mkdir('ilsvrc/val/n02134419')
+
+    def fake_image(shape=(255, 225, 3)):
+        return np.random.randint(0, 255, shape)
+
+    for subset in ['02134418', '02134419']:
+        for i in range(2):
+            fn = 'ilsvrc/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
+            cv2.imwrite(fn, fake_image())
+            cv2.imwrite('ilsvrc/val/n%s/n%s_%i.JPEG' % (subset, subset, i), fake_image())
+
+
+class ResnetTest(TestPythonScript):
+
+    @property
+    def script(self):
+        return '../examples/ResNet/imagenet-resnet.py'
+
+    def setUp(self):
+        super(ResnetTest, self).setUp()
+        fake_ilsvrc12()
+
+    def test(self):
+        self.assertSurvive(self.script, args=['--data ilsvrc', '--gpu 0'], timeout=10)
+
+    def tearDown(self):
+        super(ResnetTest, self).tearDown()
+        if os.path.isdir('ilsvrc'):
+            shutil.rmtree('ilsvrc')

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -1,27 +1,6 @@
 from case_script import TestPythonScript
 import os
 import shutil
-import tarfile
-from tensorpack.utils.fs import download, mkdir_p
-
-
-CAFFE_ILSVRC12_URL = "http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz"
-
-
-def fake_ilsvrc12():
-
-    # create directories
-    mkdir_p('ilsvrc_metadata')
-
-    # download caffe_ilsvrc12.tar.gz if not cached yet
-    tp_data_dir = os.path.join(os.environ['HOME'], 'tensorpack_data')
-    if not os.path.isfile(os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')):
-        fpath = download(CAFFE_ILSVRC12_URL, tp_data_dir)
-    else:
-        print('caffe_ilsvrc12.tar.gz already exists')
-        fpath = os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')
-    tarfile.open(fpath, 'r:gz').extractall('ilsvrc_metadata')
-
 
 class ResnetTest(TestPythonScript):
 
@@ -29,13 +8,9 @@ class ResnetTest(TestPythonScript):
     def script(self):
         return '../examples/ResNet/imagenet-resnet.py'
 
-    def setUp(self):
-        super(ResnetTest, self).setUp()
-        fake_ilsvrc12()
-
     def test(self):
-        self.assertSurvive(self.script, args=['--data ilsvrc_metadata',
-                                              '--gpu 0', '--fake True', '--data_format NHWC'], timeout=10)
+        self.assertSurvive(self.script, args=['--data .',
+                                              '--gpu 0', '--fake', '--data_format NHWC'], timeout=10)
 
     def tearDown(self):
         super(ResnetTest, self).tearDown()

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -2,6 +2,7 @@ from case_script import TestPythonScript
 import os
 import shutil
 
+
 class ResnetTest(TestPythonScript):
 
     @property

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -66,23 +66,23 @@ def fake_ilsvrc12():
 
     # create directories
     mkdir('ilsvrc_metadata')
-    mkdir('ilsvrc_metadata/train')
-    mkdir('ilsvrc_metadata/train/n02134418')
-    mkdir('ilsvrc_metadata/train/n02134419')
+    # mkdir('ilsvrc_metadata/train')
+    # mkdir('ilsvrc_metadata/train/n02134418')
+    # mkdir('ilsvrc_metadata/train/n02134419')
 
-    mkdir('ilsvrc_metadata/val')
-    mkdir('ilsvrc_metadata/test')
+    # mkdir('ilsvrc_metadata/val')
+    # mkdir('ilsvrc_metadata/test')
 
-    # image is some random noise
-    def fake_image(shape=(255, 225, 3)):
-        return np.random.randint(0, 255, shape)
+    # # image is some random noise
+    # def fake_image(shape=(255, 225, 3)):
+    #     return np.random.randint(0, 255, shape)
 
-    for subset in ['02134418', '02134419']:
-        for i in range(2):
-            fn = 'ilsvrc_metadata/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
-            cv2.imwrite(fn, fake_image())
-        cv2.imwrite('ilsvrc_metadata/val/ILSVRC2012_val_%s.JPEG' % (subset), fake_image())
-        cv2.imwrite('ilsvrc_metadata/test/ILSVRC2012_test_%s.JPEG' % (subset), fake_image())
+    # for subset in ['02134418', '02134419']:
+    #     for i in range(2):
+    #         fn = 'ilsvrc_metadata/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
+    #         cv2.imwrite(fn, fake_image())
+    #     cv2.imwrite('ilsvrc_metadata/val/ILSVRC2012_val_%s.JPEG' % (subset), fake_image())
+    #     cv2.imwrite('ilsvrc_metadata/test/ILSVRC2012_test_%s.JPEG' % (subset), fake_image())
 
     # download caffe_ilsvrc12.tar.gz if not cached yet
     tp_data_dir = os.path.join(os.environ['HOME'], 'tensorpack_data')
@@ -93,20 +93,20 @@ def fake_ilsvrc12():
         fpath = os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')
     tarfile.open(fpath, 'r:gz').extractall('ilsvrc_metadata')
 
-    # the ILSVRC dataset class uses these files to get the image paths
-    with open('ilsvrc_metadata/train.txt', 'w') as f:
-        f.write('n02134418/n02134418_0.JPEG 0\n')
-        f.write('n02134418/n02134418_1.JPEG 0\n')
-        f.write('n02134419/n02134419_0.JPEG 0\n')
-        f.write('n02134419/n02134419_1.JPEG 0\n')
+    # # the ILSVRC dataset class uses these files to get the image paths
+    # with open('ilsvrc_metadata/train.txt', 'w') as f:
+    #     f.write('n02134418/n02134418_0.JPEG 0\n')
+    #     f.write('n02134418/n02134418_1.JPEG 0\n')
+    #     f.write('n02134419/n02134419_0.JPEG 0\n')
+    #     f.write('n02134419/n02134419_1.JPEG 0\n')
 
-    with open('ilsvrc_metadata/val.txt', 'w') as f:
-        f.write('ILSVRC2012_val_02134418.JPEG 0\n')
-        f.write('ILSVRC2012_val_02134419.JPEG 0\n')
+    # with open('ilsvrc_metadata/val.txt', 'w') as f:
+    #     f.write('ILSVRC2012_val_02134418.JPEG 0\n')
+    #     f.write('ILSVRC2012_val_02134419.JPEG 0\n')
 
-    with open('ilsvrc_metadata/test.txt', 'w') as f:
-        f.write('ILSVRC2012_test_02134418.JPEG 0\n')
-        f.write('ILSVRC2012_test_02134419.JPEG 0\n')
+    # with open('ilsvrc_metadata/test.txt', 'w') as f:
+    #     f.write('ILSVRC2012_test_02134418.JPEG 0\n')
+    #     f.write('ILSVRC2012_test_02134419.JPEG 0\n')
 
 
 class ResnetTest(TestPythonScript):
@@ -120,7 +120,7 @@ class ResnetTest(TestPythonScript):
         fake_ilsvrc12()
 
     def test(self):
-        self.assertSurvive(self.script, args=['--data ilsvrc_metadata', '--gpu 0'], timeout=10)
+        self.assertSurvive(self.script, args=['--data ilsvrc_metadata', '--gpu 0', '--fake True'], timeout=10)
 
     def tearDown(self):
         super(ResnetTest, self).tearDown()

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -71,8 +71,7 @@ def fake_ilsvrc12():
     mkdir('ilsvrc/train/n02134419')
 
     mkdir('ilsvrc/val')
-    mkdir('ilsvrc/val/n02134418')
-    mkdir('ilsvrc/val/n02134419')
+    mkdir('ilsvrc/test')
 
     # image is some random noise
     def fake_image(shape=(255, 225, 3)):
@@ -82,7 +81,8 @@ def fake_ilsvrc12():
         for i in range(2):
             fn = 'ilsvrc/train/n%s/n%s_%i.JPEG' % (subset, subset, i)
             cv2.imwrite(fn, fake_image())
-            cv2.imwrite('ilsvrc/val/n%s/n%s_%i.JPEG' % (subset, subset, i), fake_image())
+        cv2.imwrite('val/ILSVRC2012_val_%s.JPEG' % (subset), fake_image())
+        cv2.imwrite('test/ILSVRC2012_test_%s.JPEG' % (subset), fake_image())
 
     # download caffe_ilsvrc12.tar.gz if not cached yet
     tp_data_dir = os.path.join(os.environ['HOME'], 'tensorpack_data')
@@ -93,18 +93,20 @@ def fake_ilsvrc12():
         fpath = os.path.join(tp_data_dir, 'caffe_ilsvrc12.tar.gz')
     tarfile.open(fpath, 'r:gz').extractall('ilsvrc')
 
-    # the ILSVRC dataset class uses this file to get the image paths
+    # the ILSVRC dataset class uses these files to get the image paths
     with open('ilsvrc/train.txt', 'w') as f:
-        f.write('ILSVRC2012_train_00000000.JPEG 65\n')
-        f.write('ILSVRC2012_train_00000001.JPEG 65\n')
+        f.write('n02134418/n02134418_0.JPEG 0\n')
+        f.write('n02134418/n02134418_1.JPEG 0\n')
+        f.write('n02134419/n02134419_0.JPEG 0\n')
+        f.write('n02134419/n02134419_1.JPEG 0\n')
 
     with open('ilsvrc/val.txt', 'w') as f:
-        f.write('ILSVRC2012_val_00000000.JPEG 65\n')
-        f.write('ILSVRC2012_val_00000001.JPEG 65\n')
+        f.write('ILSVRC2012_val_02134418.JPEG 0\n')
+        f.write('ILSVRC2012_val_02134419.JPEG 0\n')
 
     with open('ilsvrc/test.txt', 'w') as f:
-        f.write('ILSVRC2012_test_00000000.JPEG 65\n')
-        f.write('ILSVRC2012_test_00000001.JPEG 65\n')
+        f.write('ILSVRC2012_test_02134418.JPEG 0\n')
+        f.write('ILSVRC2012_test_02134419.JPEG 0\n')
 
 
 class ResnetTest(TestPythonScript):

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -120,7 +120,7 @@ class ResnetTest(TestPythonScript):
         fake_ilsvrc12()
 
     def test(self):
-        self.assertSurvive(self.script, args=['--data ilsvrc', '--gpu 0'], timeout=10)
+        self.assertSurvive(self.script, args=['--data ilsvrc_metadata', '--gpu 0'], timeout=10)
 
     def tearDown(self):
         super(ResnetTest, self).tearDown()


### PR DESCRIPTION
I started the refactoring of the tests as the previous tests were a bit hacky. Hope this is much easier to maintain. Still not happy with the `setUp` and `teastDown` duplicated code.

This addresses #153 raised in #154. 

- [x] cached MNIST dataset
- [x] testing layers (several examples)
- [x] add dummy images for more complex networks (ideally one should run build ResNet on FakeData)
- [x] remove duplicate codelines 