### PR TITLE
fix 207

### DIFF
--- a/tensorpack/dataflow/image.py
+++ b/tensorpack/dataflow/image.py
@@ -109,13 +109,14 @@ class AugmentImageComponents(MapData):
         self._nr_error = 0
 
         def func(dp):
-            copy_func = lambda x: x if copy else copy_mod.deepcopy  # noqa
+            copy_func = copy_mod.deepcopy if copy else lambda x: x  # noqa
+            dp = copy_func(dp)
             try:
-                im = copy_func(dp[index[0]])
+                im = dp[index[0]]
                 im, prms = self.augs._augment_return_params(im)
                 dp[index[0]] = im
                 for idx in index[1:]:
-                    dp[idx] = self.augs._augment(copy_func(dp[idx]), prms)
+                    dp[idx] = self.augs._augment(dp[idx], prms)
                 return dp
             except KeyboardInterrupt:
                 raise


### PR DESCRIPTION
Test this commit by:
```python
from tensorpack import *


class RepeatedDataPoint(ProxyDataFlow):

    """ Take data points from another DataFlow and produce them a certain number of times
    dp1, ..., dp1, dp2, ..., dp2, ...
    """

    def __init__(self, ds, nr):
        """
        Args:
            ds (DataFlow): input DataFlow
            nr (int): number of times to repeat each datapoint.
        """
        self.nr = nr
        super(RepeatedDataPoint, self).__init__(ds)

    def size(self):
        """
        Raises:
            :class:`ValueError` when nr == -1.
        """
        return self.ds.size() * self.nr

    def get_data(self):
        for dp in self.ds.get_data():
            for _ in range(self.nr):
                print"input is", dp[0].shape
                yield dp


ds = FakeData([(10, 10, 3)], random=False)
ds = RepeatedDataPoint(ds, nr=5)
ds = AugmentImageComponents(ds, [imgaug.RandomCrop((4, 4))], index=[0], copy=False)
ds = PrintData(ds, num=5)

```

gives
```
patwie@pc~/tmp $ python untitled.py  # without copy
input is (10, 10, 3)
input is (4, 4, 3)
input is (4, 4, 3)
input is (4, 4, 3)
input is (4, 4, 3)
[0327 12:25:58 @common.py:655] DataFlow Info:
datapoint 0<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0009, 0.9501]
datapoint 1<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0009, 0.9501]
datapoint 2<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0009, 0.9501]
datapoint 3<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0009, 0.9501]
datapoint 4<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0009, 0.9501]
patwie@pc~/tmp $ python untitled.py # with copy
input is (10, 10, 3)
input is (10, 10, 3)
input is (10, 10, 3)
input is (10, 10, 3)
input is (10, 10, 3)
[0327 12:26:08 @common.py:655] DataFlow Info:
datapoint 0<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0628, 0.9896]
datapoint 1<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0628, 0.9896]
datapoint 2<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0611, 0.9913]
datapoint 3<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0008, 0.9796]
datapoint 4<5 with 1 components consists of
   dp 0: is ndarray of shape (4, 4, 3) with range [0.0131, 0.9913]
```