### PR TITLE
Augment Tensors from Layers (fix #228)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
 
 before_script:
 - flake8 --version
+- protoc --version
 - python -c "import cv2; print('OpenCV '+ cv2.__version__)"
 - python -c "import tensorflow as tf; print('TensorFlow '+ tf.__version__)"
 

--- a/tensorpack/models/common.py
+++ b/tensorpack/models/common.py
@@ -16,7 +16,11 @@ from ..utils.develop import building_rtfd
 _LAYER_LOGGED = set()
 _LAYER_REGISTERED = {}
 
-__all__ = ['layer_register', 'disable_layer_logging', 'get_registered_layer']
+__all__ = ['layer_register', 'disable_layer_logging', 'get_registered_layer', 'EmptyObject']
+
+
+class EmptyObject(object):
+    pass
 
 
 def _register(name, func):

--- a/tensorpack/models/fc.py
+++ b/tensorpack/models/fc.py
@@ -5,7 +5,7 @@
 
 import tensorflow as tf
 
-from .common import layer_register
+from .common import layer_register, EmptyObject
 from ..tfutils import symbolic_functions as symbf
 
 __all__ = ['FullyConnected']
@@ -27,7 +27,7 @@ def FullyConnected(x, out_dim,
         use_bias (bool): whether to use bias.
 
     Returns:
-        tf.Tensor: a NC tensor named ``output``.
+        tf.Tensor: a NC tensor named ``output`` with attribute `variables`.
 
     Variable Names:
 
@@ -46,4 +46,11 @@ def FullyConnected(x, out_dim,
     if use_bias:
         b = tf.get_variable('b', [out_dim], initializer=b_init)
     prod = tf.nn.xw_plus_b(x, W, b) if use_bias else tf.matmul(x, W)
-    return nl(prod, name='output')
+
+    ret = nl(prod, name='output')
+    ret.variables = EmptyObject()
+    ret.variables.W = W
+    if use_bias:
+        ret.variables.b = b
+
+    return ret

--- a/tensorpack/models/nonlin.py
+++ b/tensorpack/models/nonlin.py
@@ -5,7 +5,7 @@
 
 import tensorflow as tf
 
-from .common import layer_register
+from .common import layer_register, EmptyObject
 from .batch_norm import BatchNorm
 
 __all__ = ['Maxout', 'PReLU', 'LeakyReLU', 'BNReLU']
@@ -54,7 +54,11 @@ def PReLU(x, init=0.001, name='output'):
     init = tf.constant_initializer(init)
     alpha = tf.get_variable('alpha', [], initializer=init)
     x = ((1 + alpha) * x + (1 - alpha) * tf.abs(x))
-    return tf.multiply(x, 0.5, name=name)
+    ret = tf.multiply(x, 0.5, name=name)
+
+    ret.variables = EmptyObject()
+    ret.variables.alpha = alpha
+    return ret
 
 
 @layer_register(use_scope=False, log_shape=False)


### PR DESCRIPTION
After writing `x = Conv2D(...)` one can now access the used variables
by `w = x.variables.W` and `b = x.variables.b` if they exists.

This is much better than writing something like:
```
w = x.name.replace('/output:0', "/W:0").replace('tower0/', '')
w = tf.get_default_graph().get_tensor_by_name(w)
```
which would also break the InferenceRunner.

Now, I also rely on this feature. And I think this the most straightforward way to access the variables. I did a grep over the *.py files in the TensorFlow repo and so far found no collision.
