### PR TITLE
Clarify LMDB-dumps and MinSaver in Documentation

### DIFF
--- a/docs/tutorial/efficient-dataflow.md
+++ b/docs/tutorial/efficient-dataflow.md
@@ -131,7 +131,7 @@ You can serialize your custom dataflow into such a LMDB file by
 
 ```python
 ds0 = dataset.ILSVRC12('/path/to/ILSVRC', 'train', shuffle=False)  # or some custom streams
-ds0 = ImageEncode(ds0, mode='.jpg', index=0)
+ds0 = ImageEncode(ds0, encoding='jpg', index=0)
 ds1 = PrefetchDataZMQ(ds0, nr_proc=1)
 dftools.dump_dataflow_to_lmdb(ds1, '/path/to/ILSVRC-train.lmdb')
 ```
@@ -171,7 +171,7 @@ Then we add necessary transformations:
     ds = LMDBData(db, shuffle=False) # produces key-value pairs
     ds = LocallyShuffleData(ds, 50000)
     ds = LMDBDataPoint(ds)  # converts 'ds' to  pairs (encoded_image, label)
-    ds = ImageDecode(ds, mode='.jpg', index=0)
+    ds = ImageDecode(ds, index=0)
     ds = AugmentImageComponent(ds, lots_of_augmentors)
     ds = BatchData(ds, 256)
 ```
@@ -189,7 +189,7 @@ Both `ImageDecode` and the augmentors can be quite slow. We can parallelize them
     ds = LocallyShuffleData(ds, 50000)
     ds = PrefetchData(ds, 5000, 1)
     ds = LMDBDataPoint(ds)
-    ds = ImageDecode(ds, mode='.jpg', index=0)
+    ds = ImageDecode(ds, index=0)
     ds = AugmentImageComponent(ds, lots_of_augmentors)
     ds = PrefetchDataZMQ(ds, 25)
     ds = BatchData(ds, 256)

--- a/tensorpack/callbacks/saver.py
+++ b/tensorpack/callbacks/saver.py
@@ -81,12 +81,19 @@ class MinSaver(Callback):
                 Defaults to ``min-{monitor_stat}.tfmodel``.
 
         Example:
-            Save the model with minimum validation error to
-            "min-val-error.tfmodel":
+            Given a summary named 'error' in your graph you can
+            save the model with minimum validation error to
+            "min-validation_error.tfmodel":
 
             .. code-block:: python
 
-                MinSaver('val-error')
+                MinSaver('validation_error')
+
+        Remarks:
+            All statistics from the validation phase in the inference runner
+            have a prefix 'validation_' to their counterpart in the training.
+            So you might use the ``validation_error`` statistic instead of the
+            ``error`` statistic.
 
         Note:
             It assumes that :class:`ModelSaver` is used with

--- a/tensorpack/dataflow/format.py
+++ b/tensorpack/dataflow/format.py
@@ -160,16 +160,15 @@ class LMDBDataPoint(MapData):
     """ Read a LMDB file and produce deserialized values.
         This can work with :func:`tensorpack.dataflow.dftools.dump_dataflow_to_lmdb`. """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, ds):
         """
         Args:
-            args, kwargs: Same as in :class:`LMDBData`.
-        """
-        if isinstance(args[0], LMDBData):
-            ds = args[0]
-        else:
-            ds = LMDBData(*args, **kwargs)
+            ds: a data stream producing key-value pairs from an lmdb file.
 
+        Remarks:
+            This requires ds to produce data which was previously saved by
+            :func:`tensorpack.dataflow.dftools.dump_dataflow_to_lmdb`.
+        """
         def f(dp):
             return loads(dp[1])
         super(LMDBDataPoint, self).__init__(ds, f)

--- a/tensorpack/dataflow/image.py
+++ b/tensorpack/dataflow/image.py
@@ -17,28 +17,32 @@ __all__ = ['ImageFromFile', 'AugmentImageComponent', 'AugmentImageComponents',
 
 class ImageEncode(MapDataComponent):
     """ Encode image as a string. """
-    def __init__(self, ds, mode='.png', index=0):
+    def __init__(self, ds, encoding='png', index=0):
         """
         Args:
             ds (DataFlow): input DataFlow.
-            mode (str): image format for compression ('.png' or '.jpg')
+            encoding (str): image format for compression ('png' or 'jpg')
             index (int): the index of the component to be encoded.
         """
+
+        assert encoding in ['png', 'jpg']
+        encoding = '.%s' % encoding
+
         def func(img):
-            return np.asarray(bytearray(cv2.imencode(mode, img)[1].tostring()), dtype=np.uint8)
+            return np.asarray(bytearray(cv2.imencode(encoding, img)[1].tostring()), dtype=np.uint8)
         super(ImageEncode, self).__init__(ds, func, index=index)
 
 
 class ImageDecode(MapDataComponent):
     """ Decode image as a string. """
-    def __init__(self, ds, index=0):
+    def __init__(self, ds, index=0, mode=cv2.IMREAD_COLOR):
         """
         Args:
             ds (DataFlow): input DataFlow.
             index (int): the index of the component to be decoded.
         """
         def func(im_data):
-            return cv2.imdecode(np.asarray(bytearray(im_data), dtype=np.uint8), cv2.IMREAD_COLOR)
+            return cv2.imdecode(np.asarray(bytearray(im_data), dtype=np.uint8), mode)
         super(ImageDecode, self).__init__(ds, func, index=index)
 
 

--- a/tensorpack/dataflow/image.py
+++ b/tensorpack/dataflow/image.py
@@ -11,7 +11,35 @@ from .imgaug import AugmentorList
 from ..utils import logger
 from ..utils.argtools import shape2d
 
-__all__ = ['ImageFromFile', 'AugmentImageComponent', 'AugmentImageComponents']
+__all__ = ['ImageFromFile', 'AugmentImageComponent', 'AugmentImageComponents',
+           'ImageEncode', 'ImageDecode']
+
+
+class ImageEncode(MapDataComponent):
+    """ Encode image as a string. """
+    def __init__(self, ds, mode='.png', index=0):
+        """
+        Args:
+            ds (DataFlow): input DataFlow.
+            mode (str): image format for compression ('.png' or '.jpg')
+            index (int): the index of the component to be encoded.
+        """
+        def func(img):
+            return np.asarray(bytearray(cv2.imencode(mode, img)[1].tostring()), dtype=np.uint8)
+        super(ImageEncode, self).__init__(ds, func, index=index)
+
+
+class ImageDecode(MapDataComponent):
+    """ Decode image as a string. """
+    def __init__(self, ds, index=0):
+        """
+        Args:
+            ds (DataFlow): input DataFlow.
+            index (int): the index of the component to be decoded.
+        """
+        def func(im_data):
+            return cv2.imdecode(np.asarray(bytearray(im_data), dtype=np.uint8), cv2.IMREAD_COLOR)
+        super(ImageDecode, self).__init__(ds, func, index=index)
 
 
 class ImageFromFile(RNGDataFlow):

--- a/tensorpack/dataflow/prefetch.py
+++ b/tensorpack/dataflow/prefetch.py
@@ -127,6 +127,8 @@ class PrefetchDataZMQ(ProxyDataFlow):
             self._size = -1
         self.nr_proc = nr_proc
 
+        logger.info('Use %i processes for prefetching.' % nr_proc)
+
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.PULL)
 


### PR DESCRIPTION
The user might be familiar with creating a ds-stream and wants to
dump the compressed image to disk as an lmdb file. This adds this to
the documentation but gives a warning about the write-performance.

In addition, there is a small amount of  documentation about the
Min-Saver and ScalarStats-runner, which is slightly now described in
more detail.