### PR TITLE
Fix incorrect slicing in expreplay when curr_size != max_size.

### DIFF
--- a/examples/DeepQNetwork/expreplay.py
+++ b/examples/DeepQNetwork/expreplay.py
@@ -90,7 +90,7 @@ class ReplayMemory(object):
         return (state, reward[-2], action[-2], isOver[-2])
 
     def _slice(self, arr, start, end):
-        s1 = arr[start:]
+        s1 = arr[start:self._curr_size]
         s2 = arr[:end]
         return np.concatenate((s1, s2), axis=0)
 


### PR DESCRIPTION
Previously, this would make s1 extend to contain all of the
uninitialized elements.