### PR TITLE
Corrected tensorflow module path for StagingArea

### DIFF
--- a/tensorpack/train/input_source.py
+++ b/tensorpack/train/input_source.py
@@ -5,7 +5,7 @@
 
 import tensorflow as tf
 try:
-    from tensorflow.contrib.staging import StagingArea
+    from tensorflow.python.ops.data_flow_ops import StagingArea
 except ImportError:
     pass
 


### PR DESCRIPTION
Bugfix for StagingArea. It appears as though Tensorflow is not adding it in the old contrib location. Should be backwards compatible.