### PR TITLE
Fix string decode issue for python3

### DIFF
--- a/tests/case_script.py
+++ b/tests/case_script.py
@@ -52,7 +52,7 @@ class PythonScript(threading.Thread):
         else:
             # something unexpected happend here, this script was supposed to survive at leat the timeout
             if len(self.err) is not 0:
-                stderr = "\n" * 5 + self.err
+                stderr = "\n\n\n\n\n %s" % self.err
                 raise AssertionError(stderr)
 
 


### PR DESCRIPTION
A binary representation `"\n" * 5 + "hh".encode('utf-8')` reproduces
the error from travis-ci.