### PR TITLE
Add name to logger.autodir for different runs and simplify

### DIFF
--- a/examples/SimilarityLearning/mnist-embeddings.py
+++ b/examples/SimilarityLearning/mnist-embeddings.py
@@ -210,7 +210,7 @@ def visualize(model_path, model):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--gpu', help='comma separated list of GPU(s) to use.', required=True)
+    parser.add_argument('--gpu', help='comma separated list of GPU(s) to use.')
     parser.add_argument('--load', help='load model')
     parser.add_argument('-a', '--algorithm', help='used algorithm', type=str,
                         choices=["siamese", "cosine", "triplet", "softtriplet"])

--- a/examples/SimilarityLearning/mnist-embeddings.py
+++ b/examples/SimilarityLearning/mnist-embeddings.py
@@ -213,7 +213,7 @@ if __name__ == '__main__':
     parser.add_argument('--load', help='load model')
     parser.add_argument('-a', '--algorithm', help='used algorithm', type=str,
                         choices=["siamese", "cosine", "triplet", "softtriplet"])
-    parser.add_argument('--visualized', help='export embeddings into an image', action='store_true')
+    parser.add_argument('--visualize', help='export embeddings into an image', action='store_true')
     args = parser.parse_args()
 
     ALGO_CONFIGS = {"siamese": SiameseModel,

--- a/examples/SimilarityLearning/mnist-embeddings.py
+++ b/examples/SimilarityLearning/mnist-embeddings.py
@@ -156,7 +156,7 @@ def get_config(model, algorithm_name):
     )
 
 
-def visualize(model_path, model):
+def visualize(model_path, model, algo_name):
     if not MATPLOTLIB_AVAIBLABLE:
         logger.error("visualize requires matplotlib package ...")
         return
@@ -203,7 +203,6 @@ def visualize(model_path, model):
 
     plt.axis([ax_min[0], ax_max[0], ax_min[1], ax_max[1]])
     plt.xticks([]), plt.yticks([])
-    algo_name = FLAGS.algorithm
     plt.title('Embedding using %s-loss' % algo_name)
     plt.savefig('%s.jpg' % algo_name)
 
@@ -226,7 +225,7 @@ if __name__ == '__main__':
 
     with change_gpu(args.gpu):
         if args.visualize:
-            visualize(args.load, ALGO_CONFIGS[args.algorithm])
+            visualize(args.load, ALGO_CONFIGS[args.algorithm], args.algorithm)
         else:
             config = get_config(ALGO_CONFIGS[args.algorithm], args.algorithm)
             if args.load:

--- a/tensorpack/utils/logger.py
+++ b/tensorpack/utils/logger.py
@@ -125,7 +125,7 @@ def disable_logger():
 
 def auto_set_dir(action=None, name=None):
     """
-    Use :func:`logger.set_logger_dir` to set log directory to 
+    Use :func:`logger.set_logger_dir` to set log directory to
     "./train_log/{scriptname}:{name}". "scriptname" is the name of the main python file currently running"""
     mod = sys.modules['__main__']
     basename = os.path.basename(mod.__file__)

--- a/tensorpack/utils/logger.py
+++ b/tensorpack/utils/logger.py
@@ -125,8 +125,8 @@ def disable_logger():
 
 def auto_set_dir(action=None, name=None):
     """
-    Set log directory to a subdir inside "train_log", with the name being
-    the main python file currently running"""
+    Use :func:`logger.set_logger_dir` to set log directory to 
+    "./train_log/{scriptname}:{name}". "scriptname" is the name of the main python file currently running"""
     mod = sys.modules['__main__']
     basename = os.path.basename(mod.__file__)
     auto_dirname = os.path.join('train_log', basename[:basename.rfind('.')])

--- a/tensorpack/utils/logger.py
+++ b/tensorpack/utils/logger.py
@@ -123,13 +123,13 @@ def disable_logger():
         globals()[func] = lambda x: None
 
 
-def auto_set_dir(action=None):
+def auto_set_dir(action=None, name=None):
     """
     Set log directory to a subdir inside "train_log", with the name being
     the main python file currently running"""
     mod = sys.modules['__main__']
     basename = os.path.basename(mod.__file__)
-    set_logger_dir(
-        os.path.join('train_log',
-                     basename[:basename.rfind('.')]),
-        action=action)
+    auto_dirname = os.path.join('train_log', basename[:basename.rfind('.')])
+    if name:
+        auto_dirname += ':%s' % name
+    set_logger_dir(auto_dirname, action=action)


### PR DESCRIPTION
I already had a previous pull-request about the same issue. This time summon the courage I try to convince you again about this feature. (see `mnist-embedding.py` for example). Sometimes, one uses the same training script (ResNet-18 vs. ResNet-50, mnist-embedding.py 'cosing' vs. mnist-embedding.py 'triplet'). But the runs all are tagged by the common scheme:

```
mynetwork0512-133348
mynetwork0515-094639
mynetwork0515-094924
mynetwork0515-095128
mynetwork0515-095232
mynetwork0515-095259
mynetwork0515-095339
mynetwork0515-095424
mynetwork0515-095619
mynetwork0515-095722
mynetwork0515-095751
mynetwork0515-100318
mynetwork0515-101107
mynetwork0515-101613
mynetwork0515-101841
mynetwork0515-102313
mynetwork0515-103231
```

while they are completely different. There are two other ways of solving this issue:
- use different files.py (ugly way duplicating code)
- always set the logger.dir manually by `logger.set_logger_dir`. But this does not give the interactive menu about `backup`, `new`, `delete`, ...

With `logger.auto_set_dir(name=some_value)` the list is much more understandable:


```
mynetwork:ideaA0512-133348
mynetwork:ideaA0515-094639
mynetwork:ideaA0515-094924
mynetwork:ideaB0515-095128
mynetwork:ideaB0515-095232
mynetwork:ideaB0515-095259
mynetwork:ideaC0515-095339
mynetwork:ideaC0515-095424
mynetwork:ideaC0515-095619
mynetwork:ideaC0515-095722
mynetwork:ideaC0515-095751
mynetwork:ideaD0515-100318
mynetwork:ideaD0515-101107
mynetwork:ideaB0515-101613
mynetwork:ideaD0515-101841
mynetwork:ideaD0515-102313
mynetwork:ideaA0515-103231
```
