### PR TITLE
Fix PTB example according to upstream changes

### DIFF
--- a/examples/PennTreebank/PTB-LSTM.py
+++ b/examples/PennTreebank/PTB-LSTM.py
@@ -54,10 +54,13 @@ class Model(ModelDesc):
         input, nextinput = inputs
         initializer = tf.random_uniform_initializer(-0.05, 0.05)
 
-        cell = rnn.BasicLSTMCell(num_units=HIDDEN_SIZE, forget_bias=0.0)
-        if is_training:
-            cell = rnn.DropoutWrapper(cell, output_keep_prob=DROPOUT)
-        cell = rnn.MultiRNNCell([cell] * NUM_LAYER)
+        def get_basic_cell():
+            cell = rnn.BasicLSTMCell(num_units=HIDDEN_SIZE, forget_bias=0.0, reuse=tf.get_variable_scope().reuse)
+            if is_training:
+                cell = rnn.DropoutWrapper(cell, output_keep_prob=DROPOUT)
+            return cell
+
+        cell = rnn.MultiRNNCell([get_basic_cell() for _ in range(NUM_LAYER)])
 
         def get_v(n):
             return tf.get_variable(n, [BATCH, HIDDEN_SIZE],

--- a/scripts/checkpoint-prof.py
+++ b/scripts/checkpoint-prof.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
         for inp in args.input:
             inp = inp.split('=')
             name = get_op_tensor_name(inp[0].strip())[1]
-            shape = map(int, inp[1].strip().split(','))
+            shape = list(map(int, inp[1].strip().split(',')))
             tensor = G.get_tensor_by_name(name)
             logger.info("Feeding shape ({}) to tensor {}".format(','.join(map(str, shape)), name))
             feed[tensor] = np.random.rand(*shape)


### PR DESCRIPTION
Around March they included a stricter checking of variable scope, which leads to incompatibility with previous RNN implementations.
https://github.com/tensorflow/tensorflow/issues/8191

According to the example below, we need to set the reuse argument.
https://github.com/tensorflow/models/blob/master/tutorials/rnn/ptb/ptb_word_lm.py