### PR TITLE
MultiGPU GAN Colocation Issue.

### DIFF
--- a/examples/GAN/GAN.py
+++ b/examples/GAN/GAN.py
@@ -119,7 +119,7 @@ class MultiGPUGANTrainer(MultiGPUTrainerBase, FeedfreeTrainerBase):
         super(MultiGPUGANTrainer, self).__init__(config)
         self._nr_gpu = config.nr_tower
         assert self._nr_gpu > 1
-        self._raw_devices = ['/gpu:{}'.format(k) for k in self.config.tower]
+        self._raw_devices = ['/device:GPU:{}'.format(k) for k in self.config.tower]
         self._input_source = StagingInputWrapper(QueueInput(config.dataflow), self._raw_devices)
 
     def _setup(self):


### PR DESCRIPTION
Fixed bug with collocation of gradients in Tensorflow 1.1. It won't colocate the gradients because it complains /GPU: is not the same as /device:GPU . Changing this line fixes the spurious warning messages when training on multiple GPUs.