### PR TITLE
Fix Predictor Build Graph

### DIFF
--- a/tensorpack/predict/base.py
+++ b/tensorpack/predict/base.py
@@ -158,7 +158,7 @@ class OfflinePredictor(OnlinePredictor):
             input = PlaceholderInput()
             input.setup(config.model.get_inputs_desc())
             with TowerContext('', is_training=False):
-                config.model.build_graph(input)
+                config.model.build_graph(input.get_input_tensors())
 
             input_tensors = get_tensors_by_names(config.input_names)
             output_tensors = get_tensors_by_names(config.output_names)


### PR DESCRIPTION
The `OfflinePredictor` in the buggy version builds graph by:
``` Python
with self.graph.as_default():
    input = PlaceholderInput()
    input.setup(config.model.get_inputs_desc())
    with TowerContext('', is_training=False):
        config.model.build_graph(input)
```
When `input` is passed into `build_graph`, it is converted to a list of tensors by:
``` Python
if len(args) == 1:
    arg = args[0]
    if isinstance(arg, InputSource):
        inputs = arg.get_input_tensors()  # remove in the future?
    if isinstance(arg, (list, tuple)):
        inputs = arg
    else:
        inputs = [arg]
else:
    inputs = args
```
However, the `inputs` returned by `get_input_tensors()` is just `[arg]`. It might because that the `InputSource` used a wrong version of the virtual method `_get_input_tensors()`.

I am using Python 3.6 by the way.