### PR TITLE
Atari Visualization Bugfix

### DIFF
--- a/examples/DeepQNetwork/atari.py
+++ b/examples/DeepQNetwork/atari.py
@@ -4,7 +4,6 @@
 # Author: Yuxin Wu <ppwwyyxxc@gmail.com>
 
 import numpy as np
-import time
 import os
 import cv2
 import threading

--- a/examples/DeepQNetwork/atari.py
+++ b/examples/DeepQNetwork/atari.py
@@ -121,7 +121,7 @@ class AtariPlayer(gym.Env):
         if self.viz:
             if isinstance(self.viz, float):
                 cv2.imshow(self.windowname, ret)
-                time.sleep(self.viz)
+                cv2.waitKey(int(self.viz * 1000))
         ret = ret.astype('float32')
         # 0.299,0.587.0.114. same as rgb2y in torch/image
         ret = cv2.cvtColor(ret, cv2.COLOR_RGB2GRAY)


### PR DESCRIPTION
OpenCV2 does not always display the visualization properly. 

For imshow to properly update, cv2.waitKey should be called. Without this line, the cv2 window does not refresh on my system with OpenCV version 2.4.9.1 on Debian with Python 2.7.9. More info can be found on [StackOverflow](https://stackoverflow.com/questions/44854699/why-does-the-cv2-imshow-does-not-render-without-cv2-waitkey).