### PR TITLE
Fixes bug with floating point images in imgaug.Hue

### DIFF
--- a/tensorpack/dataflow/imgaug/imgproc.py
+++ b/tensorpack/dataflow/imgaug/imgproc.py
@@ -34,6 +34,7 @@ class Hue(ImageAugmentor):
     def _augment(self, img, hue):
         m = cv2.COLOR_BGR2HSV if not self.rgb else cv2.COLOR_RGB2HSV
         hsv = cv2.cvtColor(img, m)
+        # https://docs.opencv.org/3.2.0/de/d25/imgproc_color_conversions.html#color_convert_rgb_hsv
         if hsv.dtype.itemsize == 1:
             # OpenCV uses 0-179 for 8-bit images
             hsv[..., 0] = (hsv[..., 0] + hue) % 180

--- a/tensorpack/dataflow/imgaug/imgproc.py
+++ b/tensorpack/dataflow/imgaug/imgproc.py
@@ -39,7 +39,7 @@ class Hue(ImageAugmentor):
             hsv[..., 0] = (hsv[..., 0] + hue) % 180
         else:
             # OpenCV uses 0-360 for floating point images
-            hsv[..., 0] = (hsv[..., 0] + 2*hue) % 360
+            hsv[..., 0] = (hsv[..., 0] + 2　*　hue) % 360
         m = cv2.COLOR_HSV2BGR if not self.rgb else cv2.COLOR_HSV2RGB
         img = cv2.cvtColor(hsv, m)
         return img

--- a/tensorpack/dataflow/imgaug/imgproc.py
+++ b/tensorpack/dataflow/imgaug/imgproc.py
@@ -18,7 +18,7 @@ class Hue(ImageAugmentor):
     def __init__(self, range=(0, 180), rgb=None):
         """
         Args:
-            range(list or tuple): hue range
+            range(list or tuple): range from which the applied hue offset is selected (maximum [-90,90] or [0,180])
             rgb (bool): whether input is RGB or BGR.
         """
         super(Hue, self).__init__()
@@ -34,9 +34,12 @@ class Hue(ImageAugmentor):
     def _augment(self, img, hue):
         m = cv2.COLOR_BGR2HSV if not self.rgb else cv2.COLOR_RGB2HSV
         hsv = cv2.cvtColor(img, m)
-        # Note, OpenCV used 0-179 degree instead of 0-359 degree
-        hsv[..., 0] = (hsv[..., 0] + hue) % 180
-
+        if hsv.dtype.itemsize == 1:
+            # OpenCV uses 0-179 for 8-bit images
+            hsv[..., 0] = (hsv[..., 0] + hue) % 180
+        else:
+            # OpenCV uses 0-360 for floating point images
+            hsv[..., 0] = (hsv[..., 0] + 2*hue) % 360
         m = cv2.COLOR_HSV2BGR if not self.rgb else cv2.COLOR_HSV2RGB
         img = cv2.cvtColor(hsv, m)
         return img


### PR DESCRIPTION
The Augmentor imgaug.Hue did not work for floating point images. I found that the hue range of cv2.cvtColor() is 0-360 for floating point images (and 0-180 for 8-bit images), see
https://docs.opencv.org/3.2.0/de/d25/imgproc_color_conversions.html#color_convert_rgb_hsv.