### PR TITLE
Accept tf.layers compatible argument names

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -376,7 +376,7 @@ def autodoc_skip_member(app, what, name, obj, skip, options):
         'PrefetchOnGPUs',
 
         'guided_relu', 'saliency_map', 'get_scalar_var', 'psnr',
-        'prediction_incorrect', 'huber_loss',
+        'prediction_incorrect', 'huber_loss', 'SoftMax'
         ]:
         return True
     if name in ['get_data', 'size', 'reset_state']:

--- a/examples/mnist-convnet.py
+++ b/examples/mnist-convnet.py
@@ -51,9 +51,9 @@ class Model(ModelDesc):
                       .Conv2D('conv2')
                       .MaxPooling('pool1', 2)
                       .Conv2D('conv3')
-                      .FullyConnected('fc0', 512, nl=tf.nn.relu)
+                      .FullyConnected('fc0', 512, activation=tf.nn.relu)
                       .Dropout('dropout', 0.5)
-                      .FullyConnected('fc1', out_dim=10, nl=tf.identity)())
+                      .FullyConnected('fc1', 10, activation=tf.identity)())
 
         tf.nn.softmax(logits, name='prob')   # a Bx10 with probabilities
 

--- a/tensorpack/models/__init__.py
+++ b/tensorpack/models/__init__.py
@@ -22,7 +22,7 @@ def _global_import(name):
 
 
 _CURR_DIR = os.path.dirname(__file__)
-_SKIP = ['utils', 'registry']
+_SKIP = ['utils', 'registry', 'tflayer']
 for _, module_name, _ in iter_modules(
         [_CURR_DIR]):
     srcpath = os.path.join(_CURR_DIR, module_name + '.py')

--- a/tensorpack/models/common.py
+++ b/tensorpack/models/common.py
@@ -3,6 +3,6 @@
 # File: common.py
 
 from .registry import layer_register    # noqa
-from .utils import VariableHolder, rename_get_variable  # noqa
+from .utils import VariableHolder  # noqa
 
 __all__ = ['layer_register', 'VariableHolder']

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -27,6 +27,8 @@ def Conv2D(x, *args, **kwargs):
         split (int): Group convolution. Defaults to 1 (no group).
             Note that this is not a fast implementation.
 
+        Other args the same as `tf.layers.Conv2D`.
+
     Variable Names:
 
     * ``W``: weights
@@ -110,6 +112,9 @@ def Deconv2D(x, *args, **kwargs):
 
     1. Default weight initializer is variance_scaling_initializer(2.0).
     2. Default padding is 'same'
+
+    Args:
+        The same as `tf.layers.Conv2DTranspose`.
 
     Variable Names:
 

--- a/tensorpack/models/conv2d.py
+++ b/tensorpack/models/conv2d.py
@@ -7,13 +7,13 @@ import tensorflow as tf
 from .common import layer_register, VariableHolder
 from ..tfutils.common import get_tf_version_number
 from ..utils.argtools import shape2d, shape4d, get_data_format
-from .tflayer import rename_get_variable, parse_args
+from .tflayer import rename_get_variable, convert_to_tflayer_args
 
 __all__ = ['Conv2D', 'Deconv2D']
 
 
 @layer_register(log_shape=True)
-@parse_args(
+@convert_to_tflayer_args(
     args_names=['filters', 'kernel_size'],
     name_mapping={
         'out_channel': 'filters',
@@ -118,7 +118,7 @@ def Conv2D(
 
 
 @layer_register(log_shape=True)
-@parse_args(
+@convert_to_tflayer_args(
     args_names=['filters', 'kernel_size', 'strides'],
     name_mapping={
         'out_channel': 'filters',

--- a/tensorpack/models/fc.py
+++ b/tensorpack/models/fc.py
@@ -5,52 +5,41 @@
 
 import tensorflow as tf
 
-from .common import layer_register, rename_get_variable, VariableHolder
+from .common import layer_register, VariableHolder
+from .tflayer import parse_args, rename_get_variable
 from ..tfutils import symbolic_functions as symbf
 
 __all__ = ['FullyConnected']
 
 
 @layer_register(log_shape=True)
-def FullyConnected(x, out_dim,
-                   W_init=None, b_init=None,
-                   activation=tf.identity, use_bias=True):
+def FullyConnected(x, *args, **kwargs):
     """
-    Fully-Connected layer, takes a N>1D tensor and returns a 2D tensor.
-    It is an equivalent of `tf.layers.dense` except for naming conventions.
+    A wrapper around `tf.layers.Dense`.
 
-    Args:
-        x (tf.Tensor): a tensor to be flattened except for the first dimension.
-        out_dim (int): output dimension
-        W_init: initializer for W. Defaults to `variance_scaling_initializer(2.0)`, i.e. kaiming-normal.
-        b_init: initializer for b. Defaults to zero.
-        nl: a nonlinearity function
-        use_bias (bool): whether to use bias.
-
-    Returns:
-        tf.Tensor: a NC tensor named ``output`` with attribute `variables`.
+    Differences: Default weight initializer is variance_scaling_initializer(2.0).
 
     Variable Names:
 
     * ``W``: weights of shape [in_dim, out_dim]
     * ``b``: bias
     """
+    tfargs = parse_args(
+        args=args, kwargs=kwargs,
+        args_names=['units'],
+        name_mapping={
+            'out_dim': 'units'
+        })
+    tfargs.setdefault('kernel_initializer', tf.contrib.layers.variance_scaling_initializer(2.0))
+    tfargs.setdefault('bias_initializer', tf.constant_initializer())
+
     x = symbf.batch_flatten(x)
 
-    if W_init is None:
-        # W_init = tf.variance_scaling_initializer(2.0)
-        W_init = tf.contrib.layers.variance_scaling_initializer(2.0)
-    if b_init is None:
-        b_init = tf.constant_initializer()
-
     with rename_get_variable({'kernel': 'W', 'bias': 'b'}):
-        layer = tf.layers.Dense(
-            out_dim, activation=activation, use_bias=use_bias,
-            kernel_initializer=W_init, bias_initializer=b_init,
-            trainable=True)
+        layer = tf.layers.Dense(**tfargs)
         ret = layer.apply(x, scope=tf.get_variable_scope())
 
     ret.variables = VariableHolder(W=layer.kernel)
-    if use_bias:
+    if tfargs.get('use_bias', True):
         ret.variables.b = layer.bias
     return tf.identity(ret, name='output')

--- a/tensorpack/models/fc.py
+++ b/tensorpack/models/fc.py
@@ -19,6 +19,9 @@ def FullyConnected(x, *args, **kwargs):
 
     Differences: Default weight initializer is variance_scaling_initializer(2.0).
 
+    Args:
+        The same as `tf.layers.Dense`.
+
     Variable Names:
 
     * ``W``: weights of shape [in_dim, out_dim]

--- a/tensorpack/models/fc.py
+++ b/tensorpack/models/fc.py
@@ -6,14 +6,14 @@
 import tensorflow as tf
 
 from .common import layer_register, VariableHolder
-from .tflayer import parse_args, rename_get_variable
+from .tflayer import convert_to_tflayer_args, rename_get_variable
 from ..tfutils import symbolic_functions as symbf
 
 __all__ = ['FullyConnected']
 
 
 @layer_register(log_shape=True)
-@parse_args(
+@convert_to_tflayer_args(
     args_names=['units'],
     name_mapping={'out_dim': 'units'})
 def FullyConnected(

--- a/tensorpack/models/pool.py
+++ b/tensorpack/models/pool.py
@@ -9,7 +9,7 @@ from .shape_utils import StaticDynamicShape
 from .common import layer_register
 from ..utils.argtools import shape2d, get_data_format
 from ._test import TestModel
-from .tflayer import parse_args
+from .tflayer import convert_to_tflayer_args
 
 
 __all__ = ['MaxPooling', 'FixedUnPooling', 'AvgPooling', 'GlobalAvgPooling',
@@ -17,8 +17,9 @@ __all__ = ['MaxPooling', 'FixedUnPooling', 'AvgPooling', 'GlobalAvgPooling',
 
 
 @layer_register(log_shape=True)
-@parse_args(args_names=['pool_size', 'strides'],
-            name_mapping={'shape': 'pool_size', 'stride': 'strides'})
+@convert_to_tflayer_args(
+    args_names=['pool_size', 'strides'],
+    name_mapping={'shape': 'pool_size', 'stride': 'strides'})
 def MaxPooling(
         inputs,
         pool_size,
@@ -36,8 +37,9 @@ def MaxPooling(
 
 
 @layer_register(log_shape=True)
-@parse_args(args_names=['pool_size', 'strides'],
-            name_mapping={'shape': 'pool_size', 'stride': 'strides'})
+@convert_to_tflayer_args(
+    args_names=['pool_size', 'strides'],
+    name_mapping={'shape': 'pool_size', 'stride': 'strides'})
 def AvgPooling(
         inputs,
         pool_size,

--- a/tensorpack/models/pool.py
+++ b/tensorpack/models/pool.py
@@ -19,7 +19,7 @@ __all__ = ['MaxPooling', 'FixedUnPooling', 'AvgPooling', 'GlobalAvgPooling',
 @layer_register(log_shape=True)
 def MaxPooling(x, *args, **kwargs):
     """
-    A wrapper around `tf.layers.MaxPooling2D`.
+    Same as `tf.layers.MaxPooling2D`.
     """
     tfargs = parse_args(
         args=args,
@@ -38,7 +38,7 @@ def MaxPooling(x, *args, **kwargs):
 @layer_register(log_shape=True)
 def AvgPooling(x, *args, **kwargs):
     """
-    A wrapper around `tf.layers.AveragePooling2D`.
+    Same as `tf.layers.AveragePooling2D`.
     """
     tfargs = parse_args(
         args=args,

--- a/tensorpack/models/pool.py
+++ b/tensorpack/models/pool.py
@@ -17,40 +17,40 @@ __all__ = ['MaxPooling', 'FixedUnPooling', 'AvgPooling', 'GlobalAvgPooling',
 
 
 @layer_register(log_shape=True)
-def MaxPooling(x, *args, **kwargs):
+@parse_args(args_names=['pool_size', 'strides'],
+            name_mapping={'shape': 'pool_size', 'stride': 'strides'})
+def MaxPooling(
+        inputs,
+        pool_size,
+        strides=None,
+        padding='valid',
+        data_format='channels_last'):
     """
-    Same as `tf.layers.MaxPooling2D`.
+    Same as `tf.layers.MaxPooling2D`. Default strides is equal to pool_size.
     """
-    tfargs = parse_args(
-        args=args,
-        kwargs=kwargs,
-        args_names=['pool_size', 'strides'],
-        name_mapping={
-            'shape': 'pool_size',
-            'stride': 'strides'})
-    if tfargs.get('strides', None) is None:
-        tfargs['strides'] = tfargs['pool_size']
-    layer = tf.layers.MaxPooling2D(**tfargs)
-    ret = layer.apply(x, scope=tf.get_variable_scope())
+    if strides is None:
+        strides = pool_size
+    layer = tf.layers.MaxPooling2D(pool_size, strides, padding=padding, data_format=data_format)
+    ret = layer.apply(inputs, scope=tf.get_variable_scope())
     return tf.identity(ret, name='output')
 
 
 @layer_register(log_shape=True)
-def AvgPooling(x, *args, **kwargs):
+@parse_args(args_names=['pool_size', 'strides'],
+            name_mapping={'shape': 'pool_size', 'stride': 'strides'})
+def AvgPooling(
+        inputs,
+        pool_size,
+        strides=None,
+        padding='valid',
+        data_format='channels_last'):
     """
-    Same as `tf.layers.AveragePooling2D`.
+    Same as `tf.layers.AveragePooling2D`. Default strides is equal to pool_size.
     """
-    tfargs = parse_args(
-        args=args,
-        kwargs=kwargs,
-        args_names=['pool_size', 'strides'],
-        name_mapping={
-            'shape': 'pool_size',
-            'stride': 'strides'})
-    if tfargs.get('strides', None) is None:
-        tfargs['strides'] = tfargs['pool_size']
-    layer = tf.layers.AveragePooling2D(**tfargs)
-    ret = layer.apply(x, scope=tf.get_variable_scope())
+    if strides is None:
+        strides = pool_size
+    layer = tf.layers.AveragePooling2D(pool_size, strides, padding=padding, data_format=data_format)
+    ret = layer.apply(inputs, scope=tf.get_variable_scope())
     return tf.identity(ret, name='output')
 
 

--- a/tensorpack/models/registry.py
+++ b/tensorpack/models/registry.py
@@ -3,7 +3,6 @@
 
 
 import tensorflow as tf
-import inspect
 from functools import wraps
 import six
 import re
@@ -106,12 +105,12 @@ def layer_register(
             actual_args = copy.copy(get_arg_scope()[func.__name__])
             # explicit kwargs overwrite argscope
             actual_args.update(kwargs)
-            if six.PY3:
-                # explicit positional args also override argscope. only work in PY3
-                posargmap = inspect.signature(func).bind_partial(*args).arguments
-                for k in six.iterkeys(posargmap):
-                    if k in actual_args:
-                        del actual_args[k]
+            # if six.PY3:
+            #     # explicit positional args also override argscope. only work in PY3
+            #     posargmap = inspect.signature(func).bind_partial(*args).arguments
+            #     for k in six.iterkeys(posargmap):
+            #         if k in actual_args:
+            #             del actual_args[k]
 
             if name is not None:        # use scope
                 with tf.variable_scope(name) as scope:

--- a/tensorpack/models/registry.py
+++ b/tensorpack/models/registry.py
@@ -11,7 +11,6 @@ import copy
 
 from ..tfutils.argscope import get_arg_scope
 from ..tfutils.model_utils import get_shape_str
-from ..utils.argtools import get_data_format
 from ..utils import logger
 
 # make sure each layer is only logged once
@@ -19,18 +18,6 @@ _LAYER_LOGGED = set()
 _LAYER_REGISTRY = {}
 
 __all__ = ['layer_register']
-
-
-def map_tfargs(kwargs):
-    df = kwargs.pop('data_format', None)
-    if df is not None:
-        df = get_data_format(df, tfmode=True)
-        kwargs['data_format'] = df
-
-    old_nl = kwargs.pop('nl', None)
-    if old_nl is not None:
-        kwargs['activation'] = lambda x, name=None: old_nl(x, name=name)
-    return kwargs
 
 
 def _register(name, func):
@@ -126,7 +113,6 @@ def layer_register(
                     if k in actual_args:
                         del actual_args[k]
 
-            actual_args = map_tfargs(actual_args)
             if name is not None:        # use scope
                 with tf.variable_scope(name) as scope:
                     # this name is only used to surpress logging, doesn't hurt to do some heuristics

--- a/tensorpack/models/regularize.py
+++ b/tensorpack/models/regularize.py
@@ -117,12 +117,10 @@ def regularize_cost_from_collection(name='regularize_cost'):
 @layer_register(use_scope=None)
 def Dropout(x, *args, **kwargs):
     """
-    A wrapper around `tf.layers.Dropout`.
-
-    Args:
-        is_training (bool): If None, will use the current :class:`tensorpack.tfutils.TowerContext`
-            to figure out.
-        kwargs: same as in `tf.layers.Dropout`.
+    Same as `tf.layers.dropout`.
+    However, for historical reasons, the first positional argument is
+    interpreted as keep_prob rather than drop_prob.
+    Explicitly use `rate=` keyword arguments to ensure things are consistent.
     """
     tfargs = parse_args(
         args=args, kwargs=kwargs,
@@ -135,7 +133,7 @@ def Dropout(x, *args, **kwargs):
         logger.warn(
             "The first positional argument to tensorpack.Dropout is the probability to keep rather than to drop. "
             "This is different from the rate argument in tf.layers.Dropout due to historical reasons. "
-            "To mimic tf.layers.Dropout, use keyword argument 'rate' instead")
+            "To mimic tf.layers.Dropout, explicitly use keyword argument 'rate' instead")
         rate = 1 - tfargs.pop('rate')
     elif 'keep_prob' in tfargs:
         assert 'rate' not in tfargs, "Cannot set both keep_prob and rate!"

--- a/tensorpack/models/softmax.py
+++ b/tensorpack/models/softmax.py
@@ -4,6 +4,7 @@
 
 import tensorflow as tf
 from .common import layer_register
+from ..utils.develop import log_deprecated
 
 __all__ = ['SoftMax']
 
@@ -28,6 +29,7 @@ def SoftMax(x, use_temperature=False, temperature_init=1.0):
 
     * ``invtemp``: 1.0/temperature.
     """
+    log_deprecated("models.SoftMax", "Please implement it by yourself!", "2018-05-01")
     if use_temperature:
         t = tf.get_variable('invtemp', [],
                             initializer=tf.constant_initializer(1.0 / float(temperature_init)))

--- a/tensorpack/models/tflayer.py
+++ b/tensorpack/models/tflayer.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# File: tflayer.py
+
+import tensorflow as tf
+import six
+
+from ..utils.argtools import get_data_format
+from ..tfutils.common import get_tf_version_number
+from ..tfutils.varreplace import custom_getter_scope
+
+
+def map_common_tfargs(kwargs):
+    df = kwargs.pop('data_format', None)
+    if df is not None:
+        df = get_data_format(df, tfmode=True)
+        kwargs['data_format'] = df
+
+    old_nl = kwargs.pop('nl', None)
+    if old_nl is not None:
+        kwargs['activation'] = lambda x, name=None: old_nl(x, name=name)
+
+    if 'W_init' in kwargs:
+        kwargs['kernel_initializer'] = kwargs.pop('W_init')
+
+    if 'b_init' in kwargs:
+        kwargs['bias_initializer'] = kwargs.pop('b_init')
+    return kwargs
+
+
+def parse_args(args, kwargs, args_names, name_mapping):
+    kwargs = map_common_tfargs(kwargs)
+
+    posarg_dic = {}
+    assert len(args) <= len(args_names), \
+        "Please use kwargs instead of positional args to call this model, " \
+        "except for the following arguments: {}".format(', '.join(args_names))
+    for pos_arg, name in zip(args, args_names):
+        posarg_dic[name] = pos_arg
+
+    ret = {}
+    for name, arg in six.iteritems(kwargs):
+        newname = name_mapping.get(name, None)
+        if newname is not None:
+            assert newname not in kwargs, \
+                "Argument {} and {} conflicts!".format(name, newname)
+        else:
+            newname = name
+        ret[newname] = arg
+    ret.update(posarg_dic)  # Let pos arg overwrite kw arg, for argscope
+    return ret
+
+
+def rename_get_variable(mapping):
+    """
+    Args:
+        mapping(dict): an old -> new mapping for variable basename. e.g. {'kernel': 'W'}
+    """
+    def custom_getter(getter, name, *args, **kwargs):
+        splits = name.split('/')
+        basename = splits[-1]
+        if basename in mapping:
+            basename = mapping[basename]
+            splits[-1] = basename
+            name = '/'.join(splits)
+        return getter(name, *args, **kwargs)
+    return custom_getter_scope(custom_getter)
+
+
+def monkeypatch_tf_layers():
+    if get_tf_version_number() < 1.4:
+        if not hasattr(tf.layers, 'Dense'):
+            from tensorflow.python.layers.core import Dense
+            tf.layers.Dense = Dense
+
+            from tensorflow.python.layers.normalization import BatchNormalization
+            tf.layers.BatchNormalization = BatchNormalization
+
+            from tensorflow.python.layers.convolutional import Conv2DTranspose, Conv2D
+            tf.layers.Conv2DTranspose = Conv2DTranspose
+            tf.layers.Conv2D = Conv2D
+
+            from tensorflow.python.layers.pooling import MaxPooling2D, AveragePooling2D
+            tf.layers.MaxPooling2D = MaxPooling2D
+            tf.layers.AveragePooling2D = AveragePooling2D
+
+
+monkeypatch_tf_layers()

--- a/tensorpack/models/tflayer.py
+++ b/tensorpack/models/tflayer.py
@@ -29,7 +29,7 @@ def map_common_tfargs(kwargs):
     return kwargs
 
 
-def parse_args(args_names, name_mapping):
+def convert_to_tflayer_args(args_names, name_mapping):
     """
     After applying this decorator:
     1. data_format becomes tf.layers style

--- a/tensorpack/models/utils.py
+++ b/tensorpack/models/utils.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 # File: utils.py
 
-import tensorflow as tf
-from ..tfutils.varreplace import custom_getter_scope
-from ..tfutils.common import get_tf_version_number
 import six
 
 
@@ -39,35 +36,3 @@ class VariableHolder(object):
             list of all variables
         """
         return list(six.itervalues(self._vars))
-
-
-def rename_get_variable(mapping):
-    """
-    Args:
-        mapping(dict): an old -> new mapping for variable basename. e.g. {'kernel': 'W'}
-    """
-    def custom_getter(getter, name, *args, **kwargs):
-        splits = name.split('/')
-        basename = splits[-1]
-        if basename in mapping:
-            basename = mapping[basename]
-            splits[-1] = basename
-            name = '/'.join(splits)
-        return getter(name, *args, **kwargs)
-    return custom_getter_scope(custom_getter)
-
-
-def monkeypatch_tf_layers():
-    if get_tf_version_number() < 1.4:
-        if not hasattr(tf.layers, 'Dense'):
-            from tensorflow.python.layers.core import Dense
-            tf.layers.Dense = Dense
-
-            from tensorflow.python.layers.normalization import BatchNormalization
-            tf.layers.BatchNormalization = BatchNormalization
-
-            from tensorflow.python.layers.convolutional import Conv2DTranspose
-            tf.layers.Conv2DTranspose = Conv2DTranspose
-
-
-monkeypatch_tf_layers()


### PR DESCRIPTION
#627 

Both old and tf.layers argument naming should be supported now. Here are some python hacks that seems to work.

BatchNorm TBD.