### PR TITLE
Fix AssertionError with repr on AugmentorList

### DIFF
--- a/tensorpack/dataflow/imgaug/base.py
+++ b/tensorpack/dataflow/imgaug/base.py
@@ -130,12 +130,12 @@ class AugmentorList(ImageAugmentor):
     Augment by a list of augmentors
     """
 
-    def __init__(self, augmentors):
+    def __init__(self, augs):
         """
         Args:
-            augmentors (list): list of :class:`ImageAugmentor` instance to be applied.
+            augs (list): list of :class:`ImageAugmentor` instance to be applied.
         """
-        self.augs = augmentors
+        self.augs = augs
         super(AugmentorList, self).__init__()
 
     def _get_augment_params(self, img):

--- a/tensorpack/dataflow/imgaug/base.py
+++ b/tensorpack/dataflow/imgaug/base.py
@@ -130,12 +130,12 @@ class AugmentorList(ImageAugmentor):
     Augment by a list of augmentors
     """
 
-    def __init__(self, augs):
+    def __init__(self, augmentors):
         """
         Args:
-            augs (list): list of :class:`ImageAugmentor` instance to be applied.
+            augmentors (list): list of :class:`ImageAugmentor` instance to be applied.
         """
-        self.augs = augs
+        self.augmentors = augmentors
         super(AugmentorList, self).__init__()
 
     def _get_augment_params(self, img):
@@ -147,7 +147,7 @@ class AugmentorList(ImageAugmentor):
         assert img.ndim in [2, 3], img.ndim
 
         prms = []
-        for a in self.augs:
+        for a in self.augmentors:
             img, prm = a._augment_return_params(img)
             prms.append(prm)
         return img, prms
@@ -155,16 +155,16 @@ class AugmentorList(ImageAugmentor):
     def _augment(self, img, param):
         check_dtype(img)
         assert img.ndim in [2, 3], img.ndim
-        for aug, prm in zip(self.augs, param):
+        for aug, prm in zip(self.augmentors, param):
             img = aug._augment(img, prm)
         return img
 
     def _augment_coords(self, coords, param):
-        for aug, prm in zip(self.augs, param):
+        for aug, prm in zip(self.augmentors, param):
             coords = aug._augment_coords(coords, prm)
         return coords
 
     def reset_state(self):
         """ Will reset state of each augmentor """
-        for a in self.augs:
+        for a in self.augmentors:
             a.reset_state()


### PR DESCRIPTION
There is an AssertionError raised if run the following code:
```python
from tensorpack.dataflow.imgaug import AugmentorList, Flip
augs = AugmentorList([Flip(horiz=True, prob=0.5), Flip(vert=True, prob=0.5)])
repr(augs)
```
and 
```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-3-8b50ed8bccdb> in <module>()
      1 augs = AugmentorList([Flip(horiz=True, prob=0.5), Flip(vert=True, prob=0.5)])
----> 2 repr(augs)

/usr/local/lib/python3.5/dist-packages/tensorpack/dataflow/imgaug/base.py in __repr__(self)
     92         for idx, f in enumerate(fields):
     93             assert hasattr(self, f), \
---> 94                 "Attribute {} not found! The default __repr__ only works if attributes match the constructor.".format(f)
     95             attr = getattr(self, f)
     96             if idx >= index_field_has_default:

AssertionError: Attribute augmentors not found! The default __repr__ only works if attributes match the constructor.
```
Due to difference between `augmentors` in `__init__` and `self.augs`.
This PR renames `augmentors` to `augs`
