### PR TITLE
GlobalAveragePooling: convert to tf.layers data_format

### DIFF
--- a/tensorpack/models/pool.py
+++ b/tensorpack/models/pool.py
@@ -57,6 +57,7 @@ def AvgPooling(
 
 
 @layer_register(log_shape=True)
+@convert_to_tflayer_args(args_names=[], name_mapping={})
 def GlobalAvgPooling(x, data_format='channels_last'):
     """
     Global average pooling as in the paper `Network In Network


### PR DESCRIPTION
Follow up to #635.

Fixes the following error loading resnet-50 weights, where gap layer output resulted in shape `[None, 7]` instead of `[None, 2048]`:

```
3rdparty/tensorpack/tensorpack/predict/base.py:170: in __init__
    config.session_init._run_init(sess)
3rdparty/tensorpack/tensorpack/tfutils/sessinit.py:220: in _run_init
    upd.update({name: value for name, value in six.iteritems(self._prms) if name in intersect})
3rdparty/tensorpack/tensorpack/tfutils/varmanip.py:111: in update
    SessionUpdate.load_value_to_var(v, value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

var = <tf.Variable 'linear/W:0' shape=(7, 1000) dtype=float32_ref>
val = array([[ 0.03154677, -0.00305561,  0.10681453, ..., -0.0088307 ,
        -0.01100363, -0.01323848],
       [-0.0161896...6],
       [ 0.00243946, -0.01400446, -0.02423655, ..., -0.01731415,
        -0.00523087, -0.00932036]], dtype=float32)
strict = False

    @staticmethod
    def load_value_to_var(var, val, strict=False):
        """
            Call `var.load(val)` with the default session.
    
            Args:
                var (tf.Variable):
                strict (bool): Behave less strict if set to False.
            """
        if strict:
            var.load(val)
            return
        name = var.op.name
    
        # check incompatible shape
        varshape = tuple(var.get_shape().as_list())
        if varshape != val.shape:
            # TODO only allow reshape when shape different by empty axis
            assert np.prod(varshape) == np.prod(val.shape), \
>               "{}: {}!={}".format(name, varshape, val.shape)
E           AssertionError: linear/W: (7, 1000)!=(2048, 1000)

3rdparty/tensorpack/tensorpack/tfutils/varmanip.py:72: AssertionError
```


