### PR TITLE
Fix RepeatedData + PrefetchDataZMQ

### DIFF
--- a/tensorpack/dataflow/common.py
+++ b/tensorpack/dataflow/common.py
@@ -330,7 +330,7 @@ class RepeatedData(ProxyDataFlow):
             :class:`ValueError` when nr == -1.
         """
         if self.nr == -1:
-            raise ValueError("size() is unavailable for infinite dataflow")
+            raise NotImplementedError("size() is unavailable for infinite dataflow")
         return self.ds.size() * self.nr
 
     def get_data(self):


### PR DESCRIPTION
Doing:

```
ds = RepeatedData(ds, -1)
ds = PrefetchDataZMQ(ds, num_workers)
ds.reset_state()
```

Would blow up, since `RepeatedData` raises a ValueError, and `PrefetchDataZMQ` only checks for `NotImplementedError`.

Not the cleanest fix but 🤷‍♂️